### PR TITLE
enhance(chess0) validate that each move is unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can use the following commands to build, test, package, and run your code.
 | `mvn package -DskipTests`  | Build an Uber jar file                          |
 | `mvn install`              | Installs the packages into the local repository |
 | `mvn test`                 | Run all the tests                               |
-| `mvn -pl shared test`     | Run all the shared tests                        |
+| `mvn -pl shared test`      | Run all the shared tests                        |
 | `mvn -pl client exec:java` | Build and run the client `Main`                 |
 | `mvn -pl server exec:java` | Build and run the server `Main`                 |
 

--- a/shared/src/test/java/passoffTests/TestFactory.java
+++ b/shared/src/test/java/passoffTests/TestFactory.java
@@ -3,6 +3,7 @@ package passoffTests;
 import chess.*;
 import org.junit.jupiter.api.Assertions;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -64,9 +65,11 @@ public class TestFactory {
         var testPiece = board.getPiece(startPosition);
         var validMoves = loadMoves(startPosition, endPositions);
 
-        var pieceMovesCollection = testPiece.pieceMoves(board, startPosition);
-        var pieceMovesSet = new HashSet<>(pieceMovesCollection);
-        Assertions.assertEquals(pieceMovesCollection.size(), pieceMovesSet.size(),
+        assertMovesEqual(valid, testPiece.pieceMoves(board, startPosition));
+    }
+    static public void assertMovesEqual(HasSet<ChessMoves> validMoves, Collection<ChessMove> providedMoves) {
+        var pieceMovesSet = new HashSet<>(providedMoves);
+        Assertions.assertEquals(providedMoves.size(), pieceMovesSet.size(),
             "Each of the generated moves should be unique");
 
         Assertions.assertEquals(validMoves, pieceMovesSet, "Wrong moves");

--- a/shared/src/test/java/passoffTests/TestFactory.java
+++ b/shared/src/test/java/passoffTests/TestFactory.java
@@ -66,7 +66,8 @@ public class TestFactory {
 
         var pieceMovesCollection = testPiece.pieceMoves(board, startPosition);
         var pieceMovesSet = new HashSet<>(pieceMovesCollection);
-        Assertions.assertEquals(pieceMovesCollection.size(), pieceMovesSet.size(), "Each of the moves generated should be unique");
+        Assertions.assertEquals(pieceMovesCollection.size(), pieceMovesSet.size(),
+            "Each of the generated moves should be unique");
 
         Assertions.assertEquals(validMoves, pieceMovesSet, "Wrong moves");
     }

--- a/shared/src/test/java/passoffTests/TestFactory.java
+++ b/shared/src/test/java/passoffTests/TestFactory.java
@@ -63,9 +63,12 @@ public class TestFactory {
         var board = loadBoard(boardText);
         var testPiece = board.getPiece(startPosition);
         var validMoves = loadMoves(startPosition, endPositions);
-        var pieceMoves = new HashSet<>(testPiece.pieceMoves(board, startPosition));
 
-        Assertions.assertEquals(validMoves, pieceMoves, "Wrong moves");
+        var pieceMovesCollection = testPiece.pieceMoves(board, startPosition);
+        var pieceMovesSet = new HashSet<>(pieceMovesCollection);
+        Assertions.assertEquals(pieceMovesCollection.size(), pieceMovesSet.size(), "Each of the moves generated should be unique");
+
+        Assertions.assertEquals(validMoves, pieceMovesSet, "Wrong moves");
     }
 
     final static Map<Character, ChessPiece.PieceType> charToTypeMap = Map.of(

--- a/shared/src/test/java/passoffTests/chessTests/chessPieceTests/PawnMoveTests.java
+++ b/shared/src/test/java/passoffTests/chessTests/chessPieceTests/PawnMoveTests.java
@@ -252,7 +252,7 @@ public class PawnMoveTests {
             validMoves.add(TestFactory.getNewMove(start, end, ChessPiece.PieceType.KNIGHT));
         }
 
-        Assertions.assertEquals(validMoves, testPiece.pieceMoves(board, start), "Wrong moves");
+        assertMovesEqual(validMoves, testPiece.pieceMoves(board, start));
     }
 
 }


### PR DESCRIPTION
If students choose to submit moves in some other form of collection rather than a `Set`, we should validate that they did not add any duplicates into their valid moves set. This is easily detected by verifying that the size of the set is the same size of their original collection.

NOTE: I considered updating the `chess.zip` file as well, but I'm not sure about the exact procedure. I would hate to have it break for students because I built it differently than normal, etc. 