### PR TITLE
Validate that moves in ArrayList are all unique

### DIFF
--- a/shared/src/test/java/passoffTests/TestFactory.java
+++ b/shared/src/test/java/passoffTests/TestFactory.java
@@ -67,7 +67,9 @@ public class TestFactory {
     }
 
     static public void validateMoves(ChessBoard board, ChessPiece testPiece, ChessPosition startPosition, Set<ChessMove> validMoves) {
-        var pieceMoves = new HashSet<>(testPiece.pieceMoves(board, startPosition));
+        var generatedMoves = testPiece.pieceMoves(board, startPosition);
+        var pieceMoves = new HashSet<>(generatedMoves);
+        Assertions.assertEquals(generatedMoves.size(), pieceMoves.size(), "Duplicate move");
         Assertions.assertEquals(validMoves, pieceMoves, "Wrong moves");
     }
 


### PR DESCRIPTION
While uncommon an uncommon issue, without this adjustment, students may be accidentally adding the same move into their array list multiple times, and it would pass. If this is the case, then the test case should fail and point out their mistake so they can clean up their move logic.