### PR TITLE
remove test scope from server -> shared dep

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>edu.byu.cs240</groupId>
             <artifactId>server</artifactId>
-            <scope>test</scope>
             <version>1.0.0</version>
         </dependency>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -68,7 +68,6 @@
             <artifactId>shared</artifactId>
             <version>1.0.0</version>
             <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>


### PR DESCRIPTION
Removing these scopes will allow tests from one module to depend on test resources from other modules (e.g. to use the `TestFactory` from the `shared` module in the `server` module)

Whether or not this is best practice is not really relevant, as inter-module resources are the default behavior in IntelliJ so any submissions that depend on this functionality pass locally but fail on the autograder