### PR TITLE
Update pom files

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -42,9 +42,9 @@
                                     </mainClass>
                                 </manifest>
                             </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                            <descriptors>
+                                <descriptor>../test-dependencies-assembly.xml</descriptor>
+                            </descriptors>
                         </configuration>
                     </execution>
                 </executions>
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>edu.byu.cs240</groupId>
             <artifactId>server</artifactId>
+            <scope>test</scope>
             <version>1.0.0</version>
         </dependency>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -47,9 +47,9 @@
                                     </mainClass>
                                 </manifest>
                             </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                            <descriptors>
+                                <descriptor>../test-dependencies-assembly.xml</descriptor>
+                            </descriptors>
                         </configuration>
                     </execution>
                 </executions>
@@ -68,6 +68,7 @@
             <artifactId>shared</artifactId>
             <version>1.0.0</version>
             <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -48,9 +48,9 @@
                                     </mainClass>
                                 </manifest>
                             </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                            <descriptors>
+                                <descriptor>../test-dependencies-assembly.xml</descriptor>
+                            </descriptors>
                         </configuration>
                     </execution>
                 </executions>

--- a/test-dependencies-assembly.xml
+++ b/test-dependencies-assembly.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>test-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useProjectAttachments>false</useProjectAttachments>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>


### PR DESCRIPTION
This updates the maven pom files to the system the autograder is currently using.

This is mostly so we can enforce the 'test' scope and prevent students from going outside the bounds of that, including contacting the database from their client production code.