### PR TITLE
Update user game command enum

### DIFF
--- a/starter-code/6-gameplay/websocket/commands/UserGameCommand.java
+++ b/starter-code/6-gameplay/websocket/commands/UserGameCommand.java
@@ -15,8 +15,7 @@ public class UserGameCommand {
     }
 
     public enum CommandType {
-        JOIN_PLAYER,
-        JOIN_OBSERVER,
+        CONNECT,
         MAKE_MOVE,
         LEAVE,
         RESIGN


### PR DESCRIPTION
This fixes the UserGameCommand CommandType enum to have CONNECT instead of JOIN_PLAYER and JOIN_OBSERVER