### PR TITLE
Update API test page

### DIFF
--- a/starter-code/3-web-api/resources/web/index.html
+++ b/starter-code/3-web-api/resources/web/index.html
@@ -82,8 +82,8 @@
             <div class="path">/game</div>
         </td>
         <td>
-            <span class="description">Join a Chess Game</span> The request body must contain the game ID. If no color is
-            specified then the user is joined as an observer. An authToken is required to call this endpoint.
+            <span class="description">Join a Chess Game</span> The request body must contain the game ID and player
+            color. An authToken is required to call this endpoint.
         </td>
     </tr>
     <tr>
@@ -116,7 +116,7 @@
 
     <button onclick="submit()">Send</button>
 </div>
-<div class="box">
+<div id="responseBox" class="box">
     <h3>Response</h3>
     <pre id="response" readonly></pre>
 </div>

--- a/starter-code/3-web-api/resources/web/index.js
+++ b/starter-code/3-web-api/resources/web/index.js
@@ -14,7 +14,7 @@ function submit() {
 
 function send(path, params, method, authToken) {
   params = !!params ? params : undefined;
-  let errStr = '';
+  let status = '';
   fetch(path, {
     method: method,
     body: params,
@@ -24,12 +24,18 @@ function send(path, params, method, authToken) {
     },
   })
     .then((response) => {
-      if (!response.ok) errStr = response.status + ': ' + response.statusText + '\n';
-      return response.json();
+      status = response.status + ': ' + response.statusText + '\n';
+      return response.text();
+    })
+    .then((text) => {
+      if(text) return JSON.parse(text);
+      else return text;
     })
     .then((data) => {
-      document.getElementById('authToken').value = data.authToken || authToken || 'none';
-      document.getElementById('response').innerText = errStr + JSON.stringify(data, null, 2);
+      document.getElementById('authToken').value = (data && data.authToken) || authToken || '';
+      const response = (data === "") ? "Empty response body" : JSON.stringify(data, null, 2);
+      document.getElementById('response').innerText = status + "\n" + response;
+      scrollToId('responseBox');
     })
     .catch((error) => {
       document.getElementById('response').innerText = error;
@@ -41,8 +47,12 @@ function displayRequest(method, endpoint, request) {
   document.getElementById('handleBox').value = endpoint;
   const body = request ? JSON.stringify(request, null, 2) : '';
   document.getElementById('requestBox').value = body;
+  scrollToId('execute');
+}
+
+function scrollToId(id) {
   window.scrollBy({
-    top: document.getElementById('execute').getBoundingClientRect().top,
+    top: document.getElementById(id).getBoundingClientRect().top,
     behavior:"smooth"
   });
 }
@@ -66,5 +76,5 @@ function createGame() {
   displayRequest('POST', '/game', { gameName: 'gameName' });
 }
 function joinGame() {
-  displayRequest('PUT', '/game', { playerColor: 'WHITE/BLACK/empty', gameID: 0 });
+  displayRequest('PUT', '/game', { playerColor: 'WHITE/BLACK', gameID: 0 });
 }


### PR DESCRIPTION
This provides a few updates to the API test page, including:

- Removes old references to empty player color and observers for the join endpoint
- Fixes some response logic to allow for empty/null response bodies (previously an error message would be displayed if an empty response body or "null" was received)
- Adjusts the response section to always display the response status code, including when the status code is 200
- Adds automatic scrolling to the response section when a response is received and displayed