### PR TITLE
Fix UserGameCommand

### DIFF
--- a/starter-code/6-gameplay/websocket/commands/UserGameCommand.java
+++ b/starter-code/6-gameplay/websocket/commands/UserGameCommand.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 /**
  * Represents a command a user can send the server over a websocket
- * 
+ *
  * Note: You can add to this class, but you should not alter the existing
  * methods.
  */
@@ -51,12 +51,12 @@ public class UserGameCommand {
         }
         UserGameCommand that = (UserGameCommand) o;
         return getCommandType() == that.getCommandType() &&
-                Objects.equals(getAuthString(), that.getAuthString()) &&
+                Objects.equals(getAuthToken(), that.getAuthToken()) &&
                 Objects.equals(getGameID(), that.getGameID());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getCommandType(), getAuthString(), getGameID());
+        return Objects.hash(getCommandType(), getAuthToken(), getGameID());
     }
 }


### PR DESCRIPTION
Not sure how I managed to pull this off, but it seems when I updated parts of the UserGameCommand at the end of Spring term I left it in a state that cannot be compiled as I changed `getAuthString` to `getAuthToken` but failed to change the `equals` and `hashCode` methods that still called `getAuthString`. 

This PR fixes `equals` and `hashCode` to call `getAuthToken` instead.

I could also undo the change and revert back to the getter being called `getAuthString` if you think that would be better.