### PR TITLE
Update WebSocketTests - Remove printStackTrace

### DIFF
--- a/starter-code/6-gameplay/passoff/server/WebSocketTests.java
+++ b/starter-code/6-gameplay/passoff/server/WebSocketTests.java
@@ -381,9 +381,8 @@ public class WebSocketTests {
                 }
             }
         } catch(AssertionError e) {
-            e.printStackTrace();
             Assertions.fail("Expected message types matching %s for %s, got %s"
-                    .formatted(Arrays.toString(expectedTypes), username, messages.reversed()));
+                    .formatted(Arrays.toString(expectedTypes), username, messages.reversed()), e);
         }
     }
 


### PR DESCRIPTION
Not sure why I added printStackTrace in the first place, this moves the throwable as the cause of the Assertions.fail rather than just printed before it.