### PR TITLE
Fix KingMoveTests method name

### DIFF
--- a/shared/src/test/java/passoff/chess/piece/KingMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piece/KingMoveTests.java
@@ -8,7 +8,7 @@ import static passoff.chess.TestUtilities.validateMoves;
 public class KingMoveTests {
 
     @Test
-    public void kingMoveUntilEdge() {
+    public void kingMiddleOfBoard() {
         validateMoves("""
                         | | | | | | | | |
                         | | | | | | | | |


### PR DESCRIPTION
Currently KingMoveTests has a method kingMoveUntilEdge which is somewhat misleading, since kings cannot move more than one square away at a time. This would replace the name with kingMiddleOfBoard