### PR TITLE
Improve Phase 1 Tests

### DIFF
--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static passoff.chess.TestUtilities.loadBoard;
+import static passoff.chess.TestUtilities.*;
 
 public class ChessBoardTests {
 
@@ -33,16 +33,7 @@ public class ChessBoardTests {
     @Test
     @DisplayName("Reset Board")
     public void defaultGameBoard() {
-        var expectedBoard = loadBoard("""
-                |r|n|b|q|k|b|n|r|
-                |p|p|p|p|p|p|p|p|
-                | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
-                |P|P|P|P|P|P|P|P|
-                |R|N|B|Q|K|B|N|R|
-                """);
+        var expectedBoard = defaultBoard();
 
         var actualBoard = new ChessBoard();
         actualBoard.resetBoard();

--- a/shared/src/test/java/passoff/chess/TestUtilities.java
+++ b/shared/src/test/java/passoff/chess/TestUtilities.java
@@ -69,12 +69,4 @@ public class TestUtilities {
         }
         return validMoves;
     }
-
-    public static void assertMoves(ChessGame game, Set<ChessMove> validMoves, ChessPosition position) {
-        var generatedMoves = game.validMoves(position);
-        var actualMoves = new HashSet<>(generatedMoves);
-        Assertions.assertEquals(generatedMoves.size(), actualMoves.size(), "Duplicate move");
-        Assertions.assertEquals(validMoves, actualMoves,
-                "ChessGame validMoves did not return the correct moves");
-    }
 }

--- a/shared/src/test/java/passoff/chess/TestUtilities.java
+++ b/shared/src/test/java/passoff/chess/TestUtilities.java
@@ -61,6 +61,19 @@ public class TestUtilities {
         return board;
     }
 
+    public static ChessBoard defaultBoard() {
+        return loadBoard("""
+                |r|n|b|q|k|b|n|r|
+                |p|p|p|p|p|p|p|p|
+                | | | | | | | | |
+                | | | | | | | | |
+                | | | | | | | | |
+                | | | | | | | | |
+                |P|P|P|P|P|P|P|P|
+                |R|N|B|Q|K|B|N|R|
+                """);
+    }
+
     public static Set<ChessMove> loadMoves(ChessPosition startPosition, int[][] endPositions) {
         var validMoves = new HashSet<ChessMove>();
         for (var endPosition : endPositions) {

--- a/starter-code/1-chess-game/passoff/chess/extracredit/CastlingTests.java
+++ b/starter-code/1-chess-game/passoff/chess/extracredit/CastlingTests.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static passoff.chess.TestUtilities.*;
+import static passoff.chess.TestUtilities.loadBoard;
 
 /**
  * Tests if the ChessGame implementation can handle Castling moves
@@ -21,7 +21,7 @@ public class CastlingTests {
     @DisplayName("White Team Castle")
     public void castleWhite() {
         ChessBoard board = loadBoard("""
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -47,7 +47,7 @@ public class CastlingTests {
         //queen side castle works correctly
         Assertions.assertDoesNotThrow(() -> game.makeMove(queenSide));
         Assertions.assertEquals(loadBoard("""
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -59,7 +59,7 @@ public class CastlingTests {
 
         //reset board
         board = loadBoard("""
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -74,7 +74,7 @@ public class CastlingTests {
         //king side castle works correctly
         Assertions.assertDoesNotThrow(() -> game.makeMove(kingSide));
         Assertions.assertEquals(loadBoard("""
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -96,7 +96,7 @@ public class CastlingTests {
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 |R| | | | | | | |
                 """);
         ChessGame game = new ChessGame();
@@ -122,7 +122,7 @@ public class CastlingTests {
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 |R| | | | | | | |
                 """), game.getBoard());
 
@@ -135,7 +135,7 @@ public class CastlingTests {
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 |R| | | | | | | |
                 """);
         game.setBoard(board);
@@ -150,7 +150,7 @@ public class CastlingTests {
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 |R| | | | | | | |
                 """), game.getBoard());
     }
@@ -160,7 +160,7 @@ public class CastlingTests {
     @DisplayName("Cannot Castle Through Pieces")
     public void castlingBlockedByTeam() {
         ChessBoard board = loadBoard("""
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -217,8 +217,8 @@ public class CastlingTests {
     @DisplayName("Cannot Castle After Moving")
     public void noCastleAfterMove() throws InvalidMoveException {
         ChessBoard board = loadBoard("""
+                | | |k| | | | | |
                 | | | | | | | | |
-                |p| | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -232,19 +232,19 @@ public class CastlingTests {
 
         //move left rook
         game.makeMove(new ChessMove(new ChessPosition(1, 1), new ChessPosition(1, 4), null));
-        game.makeMove(new ChessMove(new ChessPosition(7, 1), new ChessPosition(6, 1), null));
+        game.makeMove(new ChessMove(new ChessPosition(8, 3), new ChessPosition(8, 2), null));
 
         //move rook back to starting spot
         game.makeMove(new ChessMove(new ChessPosition(1, 4), new ChessPosition(1, 1), null));
         /*
-                | | | | | | | | |
-                | | | | | | | | |
-                |p| | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
-                |R| | | |K| | |R|
+                | |k| | | | | | |
+		        | | | | | | | | |
+		        | | | | | | | | |
+		        | | | | | | | | |
+		        | | | | | | | | |
+		        | | | | | | | | |
+		        | | | | | | | | |
+		        |R| | | |K| | |R|
          */
 
         ChessPosition kingPosition = new ChessPosition(1, 5);
@@ -258,13 +258,13 @@ public class CastlingTests {
                 "ChessGame validMoves did not contain valid king-side castle move");
 
         //move king
-        game.makeMove(new ChessMove(new ChessPosition(6, 1), new ChessPosition(5, 1), null));
+        game.makeMove(new ChessMove(new ChessPosition(8, 2), new ChessPosition(8, 3), null));
         game.makeMove(new ChessMove(kingPosition, new ChessPosition(1, 6), null));
         /*
+                | | |k| | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                |p| | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -272,14 +272,14 @@ public class CastlingTests {
          */
 
         //move king back to starting position
-        game.makeMove(new ChessMove(new ChessPosition(5, 1), new ChessPosition(4, 1), null));
+        game.makeMove(new ChessMove(new ChessPosition(8, 3), new ChessPosition(8, 4), null));
         game.makeMove(new ChessMove(new ChessPosition(1, 6), kingPosition, null));
         /*
+                | | | |k| | | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                |p| | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 |R| | | |K| | |R|

--- a/starter-code/1-chess-game/passoff/chess/extracredit/EnPassantTests.java
+++ b/starter-code/1-chess-game/passoff/chess/extracredit/EnPassantTests.java
@@ -2,11 +2,10 @@ package passoff.chess.extracredit;
 
 import chess.*;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static passoff.chess.TestUtilities.*;
+import static passoff.chess.TestUtilities.loadBoard;
 
 /**
  * Tests if the ChessGame implementation can handle En Passant moves
@@ -26,10 +25,10 @@ public class EnPassantTests {
                 | | |p| | | | | |
                 | | | | | | | | |
                 | |P| | | | | | |
+                | | | | | | | |k|
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 """);
         ChessMove setupMove = new ChessMove(new ChessPosition(7, 3), new ChessPosition(5, 3), null);
         /*
@@ -37,10 +36,10 @@ public class EnPassantTests {
                 | | | | | | | | |
                 | | | | | | | | |
                 | |P|p| | | | | |
+                | | | | | | | |k|
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
          */
 
         ChessMove enPassantMove = new ChessMove(new ChessPosition(5, 2), new ChessPosition(6, 3), null);
@@ -49,10 +48,10 @@ public class EnPassantTests {
                 | | | | | | | | |
                 | | |P| | | | | |
                 | | | | | | | | |
+                | | | | | | | |k|
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 """);
 
         assertValidEnPassant(board, ChessGame.TeamColor.BLACK, setupMove, enPassantMove, endBoard);
@@ -67,10 +66,10 @@ public class EnPassantTests {
                 | | |p| | | | | |
                 | | | | | | | | |
                 | | | |P| | | | |
+                | | | | | | | |k|
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 """);
 
         ChessMove setupMove = new ChessMove(new ChessPosition(7, 3), new ChessPosition(5, 3), null);
@@ -79,10 +78,10 @@ public class EnPassantTests {
                 | | | | | | | | |
                 | | | | | | | | |
                 | | |p|P| | | | |
+                | | | | | | | |k|
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
          */
         ChessMove enPassantMove = new ChessMove(new ChessPosition(5, 4), new ChessPosition(6, 3), null);
         ChessBoard endBoard = loadBoard("""
@@ -90,10 +89,10 @@ public class EnPassantTests {
                 | | | | | | | | |
                 | | |P| | | | | |
                 | | | | | | | | |
+                | | | | | | | |k|
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                | | | | |K| | | |
                 """);
 
         assertValidEnPassant(board, ChessGame.TeamColor.BLACK, setupMove, enPassantMove, endBoard);
@@ -104,10 +103,10 @@ public class EnPassantTests {
     @DisplayName("Black En Passant Right")
     public void enPassantBlackRight() throws InvalidMoveException {
         ChessBoard board = loadBoard("""
+                | | | |k| | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                |K| | | | | | | |
                 | | | | | |p| | |
                 | | | | | | | | |
                 | | | | | | |P| |
@@ -115,10 +114,10 @@ public class EnPassantTests {
                 """);
         ChessMove setupMove = new ChessMove(new ChessPosition(2, 7), new ChessPosition(4, 7), null);
         /*
+                | | | |k| | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                |K| | | | | | | |
                 | | | | | |p|P| |
                 | | | | | | | | |
                 | | | | | | | | |
@@ -126,10 +125,10 @@ public class EnPassantTests {
          */
         ChessMove enPassantMove = new ChessMove(new ChessPosition(4, 6), new ChessPosition(3, 7), null);
         ChessBoard endBoard = loadBoard("""
+                | | | |k| | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                |K| | | | | | | |
                 | | | | | | | | |
                 | | | | | | |p| |
                 | | | | | | | | |
@@ -144,10 +143,10 @@ public class EnPassantTests {
     @DisplayName("Black En Passant Left")
     public void enPassantBlackLeft() throws InvalidMoveException {
         ChessBoard board = loadBoard("""
+                | | | |k| | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                |K| | | | | | | |
                 | | | | | | | |p|
                 | | | | | | | | |
                 | | | | | | |P| |
@@ -155,10 +154,10 @@ public class EnPassantTests {
                 """);
         ChessMove setupMove = new ChessMove(new ChessPosition(2, 7), new ChessPosition(4, 7), null);
         /*
+                | | | |k| | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                |K| | | | | | | |
                 | | | | | | |P|p|
                 | | | | | | | | |
                 | | | | | | | | |
@@ -166,10 +165,10 @@ public class EnPassantTests {
          */
         ChessMove enPassantMove = new ChessMove(new ChessPosition(4, 8), new ChessPosition(3, 7), null);
         ChessBoard endBoard = loadBoard("""
+                | | | |k| | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
+                |K| | | | | | | |
                 | | | | | | | | |
                 | | | | | | |p| |
                 | | | | | | | | |
@@ -183,14 +182,14 @@ public class EnPassantTests {
     @DisplayName("Can Only En Passant on Next Turn")
     public void missedEnPassant() throws InvalidMoveException {
         ChessBoard board = loadBoard("""
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | |p| | | | | |
                 | | | | | | | |P|
                 | |P| | | | | | |
                 | | | | | | | | |
                 | | | | | | | |p|
                 | | | | | | | | |
-                | | | | | | | | |
+                | | | |K| | | | |
                 """);
         ChessGame game = new ChessGame();
         game.setBoard(board);
@@ -199,28 +198,28 @@ public class EnPassantTests {
         //move black piece 2 spaces
         game.makeMove(new ChessMove(new ChessPosition(7, 3), new ChessPosition(5, 3), null));
         /*
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | | | | | | | |
                 | | | | | | | |P|
                 | |P|p| | | | | |
                 | | | | | | | | |
                 | | | | | | | |p|
                 | | | | | | | | |
-                | | | | | | | | |
+                | | | |K| | | | |
          */
 
         //filler moves
         game.makeMove(new ChessMove(new ChessPosition(6, 8), new ChessPosition(7, 8), null));
         game.makeMove(new ChessMove(new ChessPosition(3, 8), new ChessPosition(2, 8), null));
         /*
-                | | | | | | | | |
+                | | | | |k| | | |
                 | | | | | | | |P|
                 | | | | | | | | |
                 | |P|p| | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | |p|
-                | | | | | | | | |
+                | | | |K| | | | |
          */
 
         //make sure pawn cannot do En Passant move

--- a/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
@@ -10,7 +10,7 @@ import static passoff.chess.TestUtilities.*;
 public class GameStatusTests {
 
     @Test
-    @DisplayName("New Game sets up default values")
+    @DisplayName("New Game Default Values")
     public void newGame() {
         var game = new ChessGame();
         var expectedBoard = defaultBoard();
@@ -19,9 +19,11 @@ public class GameStatusTests {
     }
 
     @Test
-    @DisplayName("New Game No Statuses")
+    @DisplayName("Default Board No Statuses")
     public void noGameStatuses() {
         var game = new ChessGame();
+        game.setBoard(defaultBoard());
+        game.setTeamTurn(ChessGame.TeamColor.WHITE);
 
         Assertions.assertFalse(game.isInCheck(ChessGame.TeamColor.BLACK),
                 "Black is not in check but isInCheck returned true");

--- a/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
@@ -224,4 +224,26 @@ public class GameStatusTests {
         Assertions.assertFalse(game.isInStalemate(ChessGame.TeamColor.BLACK),
                 "Black is not in a stalemate but isInStalemate returned true");
     }
+
+    @Test
+    @DisplayName("Stalemate Requires not in Check")
+    public void checkmateNotStalemate() {
+        var game = new ChessGame();
+        game.setBoard(loadBoard("""
+                |k| | | | | | | |
+                | | | | | | | | |
+                | | | | | | | | |
+                | | | | | | | | |
+                | | | | | | | | |
+                | | | | |P| | | |
+                | | | | | | | |r|
+                |K| | | | | |r| |
+                """));
+        game.setTeamTurn(ChessGame.TeamColor.WHITE);
+
+        Assertions.assertFalse(game.isInStalemate(ChessGame.TeamColor.WHITE),
+                "White is not in a stalemate but isInStalemate returned true");
+        Assertions.assertFalse(game.isInStalemate(ChessGame.TeamColor.BLACK),
+                "Black is not in a stalemate but isInStalemate returned true");
+    }
 }

--- a/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static passoff.chess.TestUtilities.loadBoard;
+import static passoff.chess.TestUtilities.*;
 
 public class GameStatusTests {
 
@@ -13,16 +13,7 @@ public class GameStatusTests {
     @DisplayName("New Game sets up default values")
     public void newGame() {
         var game = new ChessGame();
-        var expectedBoard = loadBoard("""
-                |r|n|b|q|k|b|n|r|
-                |p|p|p|p|p|p|p|p|
-                | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
-                | | | | | | | | |
-                |P|P|P|P|P|P|P|P|
-                |R|N|B|Q|K|B|N|R|
-                """);
+        var expectedBoard = defaultBoard();
         Assertions.assertEquals(expectedBoard, game.getBoard());
         Assertions.assertEquals(ChessGame.TeamColor.WHITE, game.getTeamTurn());
     }

--- a/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/GameStatusTests.java
@@ -1,7 +1,9 @@
 package passoff.chess.game;
 
-import chess.*;
-import org.junit.jupiter.api.*;
+import chess.ChessGame;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static passoff.chess.TestUtilities.loadBoard;
 

--- a/starter-code/1-chess-game/passoff/chess/game/MakeMoveTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/MakeMoveTests.java
@@ -207,6 +207,16 @@ public class MakeMoveTests {
     }
 
     @Test
+    @DisplayName("Make Move Changes Team Turn")
+    public void makeMoveChangesTurn() throws InvalidMoveException {
+        game.makeMove(new ChessMove(new ChessPosition(2, 5), new ChessPosition(4, 5), null));
+        Assertions.assertEquals(ChessGame.TeamColor.BLACK, game.getTeamTurn());
+
+        game.makeMove(new ChessMove(new ChessPosition(7, 5), new ChessPosition(5, 5), null));
+        Assertions.assertEquals(ChessGame.TeamColor.WHITE, game.getTeamTurn());
+    }
+
+    @Test
     @DisplayName("Invalid Make Move Too Far")
     public void invalidMakeMoveTooFar() {
         Assertions.assertThrows(InvalidMoveException.class,

--- a/starter-code/1-chess-game/passoff/chess/game/MakeMoveTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/MakeMoveTests.java
@@ -2,19 +2,27 @@ package passoff.chess.game;
 
 import chess.*;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import static passoff.chess.TestUtilities.loadBoard;
+import static passoff.chess.TestUtilities.*;
 
 public class MakeMoveTests {
+    private ChessGame game;
+
+    @BeforeEach
+    public void setUp() {
+        game = new ChessGame();
+        game.setTeamTurn(ChessGame.TeamColor.WHITE);
+        game.setBoard(defaultBoard());
+    }
 
     @Test
     @DisplayName("Make Valid King Move")
     public void makeValidKingMove() throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | | | | | | | | |
                 |p| | | | | | |k|
@@ -46,7 +54,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Make Valid Queen Move")
     public void makeValidQueenMove() throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | | | | | | | | |
                 | | | | | | | | |
@@ -78,7 +85,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Make Valid Rook Move")
     public void makeValidRookMove() throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | | | | |k| | | |
                 | | | | | | | | |
@@ -110,7 +116,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Make Valid Knight Move")
     public void makeValidKnightMove() throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | | | | |k| | | |
                 | | | | | | | | |
@@ -142,7 +147,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Make Valid Bishop Move")
     public void makeValidBishopMove() throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | | | | |k| | | |
                 |p| | | | | | | |
@@ -174,7 +178,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Make Valid Pawn Move")
     public void makeValidPawnMove() throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | |k| | | | | | |
                 | |p| | | | | | |
@@ -206,7 +209,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Too Far")
     public void invalidMakeMoveTooFar() {
-        var game = new ChessGame();
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(2, 1), new ChessPosition(5, 1), null)));
     }
@@ -214,7 +216,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Pawn Diagonal No Capture")
     public void invalidMakeMovePawnDiagonalNoCapture() {
-        var game = new ChessGame();
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(2, 1), new ChessPosition(3, 2), null)));
     }
@@ -222,7 +223,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Out Of Turn")
     public void invalidMakeMoveOutOfTurn() {
-        var game = new ChessGame();
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(7, 5), new ChessPosition(6, 5), null)));
     }
@@ -230,7 +230,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Through Piece")
     public void invalidMakeMoveThroughPiece() {
-        var game = new ChessGame();
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(1, 1), new ChessPosition(4, 1), null)));
     }
@@ -238,7 +237,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move No Piece")
     public void invalidMakeMoveNoPiece() {
-        var game = new ChessGame();
         //starting position does not have a piece
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(4, 4), new ChessPosition(4, 5), null)));
@@ -247,7 +245,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Invalid Move")
     public void invalidMakeMoveInvalidMove() {
-        var game = new ChessGame();
         //not a move the piece can ever take
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(8, 7), new ChessPosition(5, 5), null)));
@@ -256,7 +253,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Take Own Piece")
     public void invalidMakeMoveTakeOwnPiece() {
-        var game = new ChessGame();
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(1, 3), new ChessPosition(2, 4), null)));
     }
@@ -264,7 +260,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Captured Piece")
     public void invalidMakeMoveCapturedPiece() throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 |r|n|b|q|k|b|n|r|
                 |p|p|p|p| |p|p|p|
@@ -275,7 +270,7 @@ public class MakeMoveTests {
                 |P|P|P|P|P|P|P|P|
                 |R|N|B|Q|K|B| |R|
                 """));
-        game.setTeamTurn(ChessGame.TeamColor.WHITE);
+
         game.makeMove(new ChessMove(new ChessPosition(3, 6), new ChessPosition(5, 5), null));
         Assertions.assertThrows(InvalidMoveException.class,
                 () -> game.makeMove(new ChessMove(new ChessPosition(5, 5), new ChessPosition(4, 5), null)));
@@ -284,7 +279,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Jump Enemy")
     public void invalidMakeMoveJumpEnemy() {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | | | | |k| | | |
                 | | | | | | | | |
@@ -302,7 +296,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move In Check")
     public void invalidMakeMoveInCheck() {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 |r|n| |q|k|b| |r|
                 |p| |p|p|p|p|p|p|
@@ -321,7 +314,6 @@ public class MakeMoveTests {
     @Test
     @DisplayName("Invalid Make Move Double Move Moved Pawn")
     public void invalidMakeMoveDoubleMoveMovedPawn() {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 |r|n|b|q|k|b|n|r|
                 |p| |p|p|p|p|p|p|
@@ -341,7 +333,6 @@ public class MakeMoveTests {
     @EnumSource(value = ChessPiece.PieceType.class, names = {"QUEEN", "ROOK", "KNIGHT", "BISHOP"})
     @DisplayName("Pawn Promotion")
     public void promotionMoves(ChessPiece.PieceType promotionType) throws InvalidMoveException {
-        var game = new ChessGame();
         game.setBoard(loadBoard("""
                 | | | | | | | | |
                 | | |P| | | | | |
@@ -352,7 +343,6 @@ public class MakeMoveTests {
                 | |K| | |p| | | |
                 | | | | | |Q| | |
                 """));
-        game.setTeamTurn(ChessGame.TeamColor.WHITE);
 
         //White promotion
         ChessMove whitePromotion = new ChessMove(new ChessPosition(7, 3), new ChessPosition(8, 3), promotionType);
@@ -369,6 +359,7 @@ public class MakeMoveTests {
 
 
         //Black take + promotion
+        game.setTeamTurn(ChessGame.TeamColor.BLACK);
         ChessMove blackPromotion = new ChessMove(new ChessPosition(2, 5), new ChessPosition(1, 6), promotionType);
         game.makeMove(blackPromotion);
 

--- a/starter-code/1-chess-game/passoff/chess/game/MakeMoveTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/MakeMoveTests.java
@@ -345,11 +345,11 @@ public class MakeMoveTests {
         game.setBoard(loadBoard("""
                 | | | | | | | | |
                 | | |P| | | | | |
+                | | | | | | |k| |
                 | | | | | | | | |
                 | | | | | | | | |
                 | | | | | | | | |
-                | | | | | | | | |
-                | | | | |p| | | |
+                | |K| | |p| | | |
                 | | | | | |Q| | |
                 """));
         game.setTeamTurn(ChessGame.TeamColor.WHITE);

--- a/starter-code/1-chess-game/passoff/chess/game/ValidMovesTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/ValidMovesTests.java
@@ -18,6 +18,7 @@ public class ValidMovesTests {
     public void forcedMove() {
 
         var game = new ChessGame();
+        game.setTeamTurn(ChessGame.TeamColor.BLACK);
         game.setBoard(loadBoard("""
                     | | | | | | | | |
                     | | | | | | | | |
@@ -92,6 +93,7 @@ public class ValidMovesTests {
     public void kingInDanger() {
 
         var game = new ChessGame();
+        game.setTeamTurn(ChessGame.TeamColor.BLACK);
         game.setBoard(loadBoard("""
                     |R| | | | | | | |
                     | | | |k| | | |b|
@@ -149,6 +151,20 @@ public class ValidMovesTests {
         ChessPosition position = new ChessPosition(2, 6);
         var validMoves = loadMoves(position, new int[][]{
                 {1, 5}, {1, 6}, {1, 7}, {2, 5}, {2, 7},
+        });
+        assertMoves(game, validMoves, position);
+    }
+
+    @Test
+    @DisplayName("Valid Moves Independent of Team Turn")
+    public void validMovesOtherTeam() {
+        var game = new ChessGame();
+        game.setBoard(defaultBoard());
+        game.setTeamTurn(ChessGame.TeamColor.BLACK);
+
+        ChessPosition position = new ChessPosition(2, 5);
+        var validMoves = loadMoves(position, new int[][]{
+                {3, 5}, {4, 5}
         });
         assertMoves(game, validMoves, position);
     }

--- a/starter-code/1-chess-game/passoff/chess/game/ValidMovesTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/ValidMovesTests.java
@@ -1,10 +1,14 @@
 package passoff.chess.game;
 
 import chess.ChessGame;
+import chess.ChessMove;
 import chess.ChessPosition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static passoff.chess.TestUtilities.*;
 
@@ -147,5 +151,13 @@ public class ValidMovesTests {
                 {1, 5}, {1, 6}, {1, 7}, {2, 5}, {2, 7},
         });
         assertMoves(game, validMoves, position);
+    }
+
+    public static void assertMoves(ChessGame game, Set<ChessMove> validMoves, ChessPosition position) {
+        var generatedMoves = game.validMoves(position);
+        var actualMoves = new HashSet<>(generatedMoves);
+        Assertions.assertEquals(generatedMoves.size(), actualMoves.size(), "Duplicate move");
+        Assertions.assertEquals(validMoves, actualMoves,
+                "ChessGame validMoves did not return the correct moves");
     }
 }

--- a/starter-code/1-chess-game/passoff/chess/game/ValidMovesTests.java
+++ b/starter-code/1-chess-game/passoff/chess/game/ValidMovesTests.java
@@ -50,7 +50,7 @@ public class ValidMovesTests {
                     | | | | | | | | |
                     | | | | | | | | |
                     | | | | | | | | |
-                    | |r| | | |R| |K|
+                    |k|r| | | |R| |K|
                     | | | | | | | | |
                     | | | | | | | | |
                     | | | | | | | | |
@@ -71,7 +71,7 @@ public class ValidMovesTests {
 
         var game = new ChessGame();
         game.setBoard(loadBoard("""
-                    | | | | | | | |Q|
+                    |K| | | | | | |Q|
                     | | | | | | | | |
                     | | | | | | | | |
                     | | | | | | | | |
@@ -96,7 +96,7 @@ public class ValidMovesTests {
                     |R| | | | | | | |
                     | | | |k| | | |b|
                     | | | | |P| | | |
-                    | | |Q|n| | | | |
+                    |K| |Q|n| | | | |
                     | | | | | | | | |
                     | | | | | | | |r|
                     | | | | | |p| | |


### PR DESCRIPTION
This semester, a lot of students had several issues with the tests that could have been mitigated. This PR hopes to address most, if not all, that I remember seeing.

This changes:
- Puts a exactly two kings, one of each color on each board used in the tests (including extra credit tests)
- Adds three new tests in cases that were covered but by tests testing for other things, which seemed to confuse many students. Having dedicated tests for these three cases should hopefully reduce the number of questions we get about this.
    - Valid Moves Independent of Team Turn - this was previously covered by two other valid moves tests that weren't specifically about being independent of team turn. This also removes the coverage for this in the other tests
    - Make Move Changes Team Turn - previously only covered by the Pawn Promotion test and Full Game Test. This also removes the coverage in Pawn Promotion
    - Stalemate Requires not in Check - previously only covered by Full Game Test.
- Removes the assumption of many of the MakeMoveTests that the New Game Default Values test would pass. A BeforeEach method now sets up a default board and the white player's turn. This was causing a lot of the make move tests to pass when they should not have, and break after code to pass the default values test was added. Now it should only pass when the code is setup correctly for what it's testing 