### PR TITLE
Update WebSocketTests.java Add connectSingleUser Test

### DIFF
--- a/starter-code/6-gameplay/passoff/server/WebSocketTests.java
+++ b/starter-code/6-gameplay/passoff/server/WebSocketTests.java
@@ -61,9 +61,16 @@ public class WebSocketTests {
 
     @Test
     @Order(1)
+    @DisplayName("Connect 1 User")
+    public void connectSingleUser() {
+        connectToGame(white, gameID, true, Set.of(), Set.of()); //Connects 1 User to the game
+    }
+
+    @Test
+    @Order(2)
     @DisplayName("Normal Connect")
     public void connectGood() {
-        setupNormalGame();
+        setupNormalGame();    //Connects 3 Users to the game, and notifies others upon connection
     }
 
     @Test


### PR DESCRIPTION
Tried to help someone who was using WebsocketTests to test their Connect functionality. Ran into an issue with Normal Connect because there was no distinction between 1 user connection (which doesn't require a notification message), and 3 users connecting (which does require a notification message). 

We provided the students a starting place, which would mean this test should be run first, and additional tests running multiple different connects would want to run afterwards.