### PR TITLE
Fix Phase 0 tests: nullability issues

### DIFF
--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -21,6 +21,7 @@ public class ChessBoardTests {
 
         ChessPiece foundPiece = board.getPiece(position);
 
+        Assertions.assertNotNull(foundPiece, "getPiece returned null for a position just added");
         Assertions.assertEquals(piece.getPieceType(), foundPiece.getPieceType(),
                 "ChessPiece returned by getPiece had the wrong piece type");
         Assertions.assertEquals(piece.getTeamColor(), foundPiece.getTeamColor(),
@@ -36,7 +37,7 @@ public class ChessBoardTests {
         var actualBoard = new ChessBoard();
         actualBoard.resetBoard();
 
-        Assertions.assertEquals(expectedBoard, actualBoard);
+        Assertions.assertEquals(expectedBoard, actualBoard, "Reset board did not create the correct board");
     }
 
 

--- a/shared/src/test/java/passoff/chess/TestUtilities.java
+++ b/shared/src/test/java/passoff/chess/TestUtilities.java
@@ -12,14 +12,16 @@ public class TestUtilities {
     public static void validateMoves(String boardText, ChessPosition startPosition, int[][] endPositions) {
         var board = loadBoard(boardText);
         var testPiece = board.getPiece(startPosition);
+        Assertions.assertNotNull(testPiece, "Could not find piece on board");
         var validMoves = loadMoves(startPosition, endPositions);
         validateMoves(board, testPiece, startPosition, validMoves);
     }
 
     public static void validateMoves(ChessBoard board, ChessPiece testPiece, ChessPosition startPosition,
                                      List<ChessMove> validMoves) {
-        var pieceMoves = new ArrayList<>(testPiece.pieceMoves(board, startPosition));
-        validateMoves(validMoves, pieceMoves);
+        var pieceMoves = testPiece.pieceMoves(board, startPosition);
+        Assertions.assertNotNull(pieceMoves, "pieceMoves returned null");
+        validateMoves(validMoves, new ArrayList<>(pieceMoves));
     }
 
     public static void validateMoves(List<ChessMove> expected, List<ChessMove> actual) {

--- a/shared/src/test/java/passoff/chess/piece/PawnMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piece/PawnMoveTests.java
@@ -3,6 +3,7 @@ package passoff.chess.piece;
 import chess.ChessMove;
 import chess.ChessPiece;
 import chess.ChessPosition;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import passoff.chess.TestUtilities;
 
@@ -412,6 +413,7 @@ public class PawnMoveTests {
     private static void validatePromotion(String boardText, ChessPosition startingPosition, int[][] endPositions) {
         var board = TestUtilities.loadBoard(boardText);
         var testPiece = board.getPiece(startingPosition);
+        Assertions.assertNotNull(testPiece, "Could not find piece on board");
         var validMoves = new ArrayList<ChessMove>();
         for (var endPosition : endPositions) {
             var end = new ChessPosition(endPosition[0], endPosition[1]);


### PR DESCRIPTION
## Key Points
- **This PR does not change any requirements.**
- This PR merely offers improved error messages in the case that student's return `null` from their methods which result would have failed anyways.

## Overview
This semester, a couple of students have posted issues in slack of the test cases themselves throwing `NullPointerException`s. Both times this was caused by the student's code returning null from a method that shouldn't have, but I figured it would be pretty easy to check that and give them a more helpful error message if they return `null`.

## Discussion

~Not sure who to request a review from, but this doesn't necessarily need to be merged in any time soon, so I can let it sit here.~

This PR has been changed to merge into the newly created `next-spring2025` branch and can be reviewed and merged immediately.