### PR TITLE
Chess Piece tests

### DIFF
--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -59,21 +59,4 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
         Assertions.assertEquals(expectedBoard, actualBoard);
     }
 
-
-    @Test
-    @DisplayName("Piece Move on All Pieces")
-    public void pieceMoveAllPieces() {
-        var board = new ChessBoard();
-        board.resetBoard();
-        for(int i = 1; i <= 8; i++) {
-            for(int j = 1; j <= 8; j++) {
-                ChessPosition position = new ChessPosition(i, j);
-                ChessPiece piece = board.getPiece(position);
-                if(piece != null) {
-                    Assertions.assertDoesNotThrow(() -> piece.pieceMoves(board, position));
-                }
-            }
-        }
-    }
-
 }

--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -8,7 +8,27 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class ChessBoardTests {
+import java.util.Collection;
+import java.util.List;
+
+public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
+    public ChessBoardTests() {
+        super("ChessBoard", "boards");
+    }
+
+    @Override
+    protected ChessBoard buildOriginal() {
+        var basicBoard = new ChessBoard();
+        basicBoard.resetBoard();
+        return basicBoard;
+    }
+
+    @Override
+    protected Collection<ChessBoard> buildAllDifferent() {
+        return List.of(
+                new ChessBoard() // Empty
+        );
+    }
 
     @Test
     @DisplayName("Add and Get Piece")

--- a/shared/src/test/java/passoff/chess/ChessMoveTests.java
+++ b/shared/src/test/java/passoff/chess/ChessMoveTests.java
@@ -51,7 +51,7 @@ public class ChessMoveTests {
     }
 
     @Test
-    @DisplayName("Combined Testing")
+    @DisplayName("Equals & HashCode Testing")
     public void hashSetTest() {
         Set<ChessMove> set = new HashSet<>();
         set.add(original);

--- a/shared/src/test/java/passoff/chess/ChessMoveTests.java
+++ b/shared/src/test/java/passoff/chess/ChessMoveTests.java
@@ -24,12 +24,10 @@ public class ChessMoveTests extends EqualsTestingUtility<ChessMove> {
                 new ChessMove(new ChessPosition(1, 5), new ChessPosition(2, 6), null),
                 new ChessMove(new ChessPosition(2, 4), new ChessPosition(1, 5), null),
                 new ChessMove(new ChessPosition(2, 6), new ChessPosition(5, 3), null),
-                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.KING), // hehe :)
                 new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.QUEEN),
                 new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.ROOK),
                 new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.BISHOP),
-                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.KNIGHT),
-                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.PAWN)
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.KNIGHT)
         );
     }
 

--- a/shared/src/test/java/passoff/chess/ChessMoveTests.java
+++ b/shared/src/test/java/passoff/chess/ChessMoveTests.java
@@ -3,77 +3,35 @@ package passoff.chess;
 import chess.ChessMove;
 import chess.ChessPiece;
 import chess.ChessPosition;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collection;
+import java.util.List;
 
 
-public class ChessMoveTests {
-    private ChessMove original;
-    private ChessMove equal;
-    private ChessMove startDifferent;
-    private ChessMove endDifferent;
-    private ChessMove promoteDifferent;
-    @BeforeEach
-    public void setUp() {
-        original = new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), null);
-        equal = new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), null);
-        startDifferent = new ChessMove(new ChessPosition(2, 4), new ChessPosition(1, 5), null);
-        endDifferent = new ChessMove(new ChessPosition(2, 6), new ChessPosition(5, 3), null);
-        promoteDifferent = new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5),
-                ChessPiece.PieceType.QUEEN);
+public class ChessMoveTests extends EqualsTestingUtility<ChessMove> {
+    public ChessMoveTests() {
+        super("ChessMove", "moves");
     }
 
-    @Test
-    @DisplayName("Equals Testing")
-    public void equalsTest() {
-        Assertions.assertEquals(original, equal, "equals returned false for equal moves");
-        Assertions.assertNotEquals(original, startDifferent, "equals returned true for different moves");
-        Assertions.assertNotEquals(original, endDifferent, "equals returned true for different moves");
-        Assertions.assertNotEquals(original, promoteDifferent, "equals returned true for different moves");
+    @Override
+    protected ChessMove buildOriginal() {
+        return new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), null);
     }
 
-    @Test
-    @DisplayName("HashCode Testing")
-    public void hashTest() {
-        Assertions.assertEquals(original.hashCode(), equal.hashCode(),
-                "hashCode returned different values for equal moves");
-        Assertions.assertNotEquals(original.hashCode(), startDifferent.hashCode(),
-                "hashCode returned the same value for different moves");
-        Assertions.assertNotEquals(original.hashCode(), endDifferent.hashCode(),
-                "hashCode returned the same value for different moves");
-        Assertions.assertNotEquals(original.hashCode(), promoteDifferent.hashCode(),
-                "hashCode returned the same value for different moves");
+    @Override
+    protected Collection<ChessMove> buildAllDifferent() {
+        return List.of(
+                new ChessMove(new ChessPosition(1, 5), new ChessPosition(2, 6), null),
+                new ChessMove(new ChessPosition(2, 4), new ChessPosition(1, 5), null),
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(5, 3), null),
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.KING), // hehe :)
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.QUEEN),
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.ROOK),
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.BISHOP),
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.KNIGHT),
+                new ChessMove(new ChessPosition(2, 6), new ChessPosition(1, 5), ChessPiece.PieceType.PAWN)
+        );
     }
 
-    @Test
-    @DisplayName("Equals & HashCode Testing")
-    public void hashSetTest() {
-        Set<ChessMove> set = new HashSet<>();
-        set.add(original);
-
-        Assertions.assertTrue(set.contains(original));
-        Assertions.assertTrue(set.contains(equal));
-        Assertions.assertEquals(1, set.size());
-        set.add(equal);
-        Assertions.assertEquals(1, set.size());
-
-        Assertions.assertFalse(set.contains(startDifferent));
-        set.add(startDifferent);
-        Assertions.assertEquals(2, set.size());
-
-        Assertions.assertFalse(set.contains(endDifferent));
-        set.add(endDifferent);
-        Assertions.assertEquals(3, set.size());
-
-        Assertions.assertFalse(set.contains(promoteDifferent));
-        set.add(promoteDifferent);
-        Assertions.assertEquals(4, set.size());
-
-    }
 
 }

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -13,17 +13,12 @@ public class ChessPieceTests extends EqualsTestingUtility<ChessPiece> {
     }
 
     @Override
-    protected ChessPiece getOriginal() {
+    protected ChessPiece buildOriginal() {
         return new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
     }
 
     @Override
-    protected ChessPiece getEqual() {
-        return new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
-    }
-
-    @Override
-    protected Collection<ChessPiece> getAllDifferent() {
+    protected Collection<ChessPiece> buildAllDifferent() {
         return List.of(
                 new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.QUEEN)
         );

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -1,8 +1,14 @@
 package passoff.chess;
 
+import chess.ChessBoard;
 import chess.ChessGame;
 import chess.ChessPiece;
+import chess.ChessPosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -25,6 +31,37 @@ public class ChessPieceTests extends EqualsTestingUtility<ChessPiece> {
                 new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.PAWN),
                 new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.PAWN)
         );
+    }
+
+
+    @Test
+    @DisplayName("Piece Move on All Pieces")
+    public void pieceMoveAllPieces() {
+        var board = new ChessBoard();
+
+        // 6 piece types * 2 team colors = 12 different pieces
+        Collection<ChessPiece> allPossiblePieces =
+                Arrays.stream(ChessPiece.PieceType.values())
+                .flatMap(pieceType -> Arrays.stream(ChessGame.TeamColor.values())
+                .map(teamColor -> new ChessPiece(teamColor, pieceType)))
+                .toList();
+
+        // 8 rows * 8 cols * 12 pieces = 768 evaluations
+        for (int i = 1; i <= 8; i++) {
+            for (int j = 1; j <= 8; j++) {
+                ChessPosition position = new ChessPosition(i, j);
+
+                for (var piece : allPossiblePieces) {
+                    board.addPiece(position, piece);
+                    Assertions.assertDoesNotThrow(
+                            () -> piece.pieceMoves(board, position),
+                            "No pieces anywhere on the board should throw an error. "
+                            + "Tested: " + piece + " at " + position + ".");
+                }
+
+                board.addPiece(position, null);
+            }
+        }
     }
 
 }

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -35,7 +35,7 @@ public class ChessPieceTests {
     }
 
     @Test
-    @DisplayName("Combined Testing")
+    @DisplayName("Equals & HashCode Testing")
     public void hashSetTest() {
         // FIXME: Add thorough testing for equality differences
     }

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -20,7 +20,11 @@ public class ChessPieceTests extends EqualsTestingUtility<ChessPiece> {
     @Override
     protected Collection<ChessPiece> buildAllDifferent() {
         return List.of(
-                new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.QUEEN)
+                new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.KING),
+                new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.QUEEN),
+                new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.QUEEN),
+                new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.PAWN),
+                new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.PAWN)
         );
     }
 

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -2,41 +2,31 @@ package passoff.chess;
 
 import chess.ChessGame;
 import chess.ChessPiece;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
-public class ChessPieceTests {
-    private ChessPiece original;
-    private ChessPiece equal;
-    private ChessPiece different;
-    @BeforeEach
-    public void setUp() {
-        original = new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
-        equal = new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
-        different = new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.QUEEN);
+import java.util.Collection;
+import java.util.List;
+
+public class ChessPieceTests extends EqualsTestingUtility<ChessPiece> {
+    @Override
+    protected String getItemsPlural() {
+        return "pieces";
     }
 
-    @Test
-    @DisplayName("Equals Testing")
-    public void equalsTest() {
-        Assertions.assertEquals(original, equal, "equals returned false for equal pieces");
-        Assertions.assertNotEquals(original, different, "equals returned true for different pieces");
+    @Override
+    protected ChessPiece getOriginal() {
+        return new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
     }
 
-    @Test
-    @DisplayName("HashCode Testing")
-    public void hashTest() {
-        Assertions.assertEquals(original.hashCode(), equal.hashCode(),
-                "hashCode returned different values for equal pieces");
-        Assertions.assertNotEquals(original.hashCode(), different.hashCode(),
-                "hashCode returned the same value for different pieces");
+    @Override
+    protected ChessPiece getEqual() {
+        return new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
     }
 
-    @Test
-    @DisplayName("Equals & HashCode Testing")
-    public void hashSetTest() {
-        // FIXME: Add thorough testing for equality differences
+    @Override
+    protected Collection<ChessPiece> getAllDifferent() {
+        return List.of(
+                new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.QUEEN)
+        );
     }
+
 }

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -1,0 +1,42 @@
+package passoff.chess;
+
+import chess.ChessGame;
+import chess.ChessPiece;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ChessPieceTests {
+    private ChessPiece original;
+    private ChessPiece equal;
+    private ChessPiece different;
+    @BeforeEach
+    public void setUp() {
+        original = new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
+        equal = new ChessPiece(ChessGame.TeamColor.WHITE, ChessPiece.PieceType.KING);
+        different = new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.QUEEN);
+    }
+
+    @Test
+    @DisplayName("Equals Testing")
+    public void equalsTest() {
+        Assertions.assertEquals(original, equal, "equals returned false for equal pieces");
+        Assertions.assertNotEquals(original, different, "equals returned true for different pieces");
+    }
+
+    @Test
+    @DisplayName("HashCode Testing")
+    public void hashTest() {
+        Assertions.assertEquals(original.hashCode(), equal.hashCode(),
+                "hashCode returned different values for equal pieces");
+        Assertions.assertNotEquals(original.hashCode(), different.hashCode(),
+                "hashCode returned the same value for different pieces");
+    }
+
+    @Test
+    @DisplayName("Combined Testing")
+    public void hashSetTest() {
+        // FIXME: Add thorough testing for equality differences
+    }
+}

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -46,12 +46,16 @@ public class ChessPieceTests extends EqualsTestingUtility<ChessPiece> {
                 .map(teamColor -> new ChessPiece(teamColor, pieceType)))
                 .toList();
 
-        // 8 rows * 8 cols * 12 pieces = 768 evaluations
+        // 8 rows * 8 cols * 12 pieces = 768 evaluations - 32 pawns on back rows
         for (int i = 1; i <= 8; i++) {
             for (int j = 1; j <= 8; j++) {
                 ChessPosition position = new ChessPosition(i, j);
 
                 for (var piece : allPossiblePieces) {
+                    if (piece.getPieceType() == ChessPiece.PieceType.PAWN && (i == 1 || i == 8)) {
+                        continue;
+                    }
+
                     board.addPiece(position, piece);
                     Assertions.assertDoesNotThrow(
                             () -> piece.pieceMoves(board, position),

--- a/shared/src/test/java/passoff/chess/ChessPieceTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPieceTests.java
@@ -7,9 +7,8 @@ import java.util.Collection;
 import java.util.List;
 
 public class ChessPieceTests extends EqualsTestingUtility<ChessPiece> {
-    @Override
-    protected String getItemsPlural() {
-        return "pieces";
+    public ChessPieceTests() {
+        super("ChessPiece", "pieces");
     }
 
     @Override

--- a/shared/src/test/java/passoff/chess/ChessPositionTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPositionTests.java
@@ -1,58 +1,30 @@
 package passoff.chess;
 
 import chess.ChessPosition;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collection;
+import java.util.List;
 
-public class ChessPositionTests {
-    private ChessPosition original;
-    private ChessPosition equal;
-    private ChessPosition different;
-    @BeforeEach
-    public void setUp() {
-        original = new ChessPosition(3, 7);
-        equal = new ChessPosition(3, 7);
-        different = new ChessPosition(7, 3);
+public class ChessPositionTests extends EqualsTestingUtility<ChessPosition> {
+    public ChessPositionTests() {
+        super("ChessPosition", "positions");
     }
 
-    @Test
-    @DisplayName("Equals Testing")
-    public void equalsTest() {
-        Assertions.assertEquals(original, equal, "equals returned false for equal positions");
-        Assertions.assertNotEquals(original, different, "equals returned true for different positions");
+    @Override
+    protected ChessPosition buildOriginal() {
+        return new ChessPosition(3, 7);
     }
 
-    @Test
-    @DisplayName("HashCode Testing")
-    public void hashTest() {
-        Assertions.assertEquals(original.hashCode(), equal.hashCode(),
-                "hashCode returned different values for equal positions");
-        Assertions.assertNotEquals(original.hashCode(), different.hashCode(),
-                "hashCode returned the same value for different positions");
-    }
-
-    @Test
-    @DisplayName("Equals & HashCode Testing")
-    public void hashSetTest() {
-        Set<ChessPosition> set = new HashSet<>();
-        set.add(original);
-
-        Assertions.assertTrue(set.contains(original));
-        Assertions.assertTrue(set.contains(equal));
-        Assertions.assertEquals(1, set.size());
-        set.add(equal);
-        Assertions.assertEquals(1, set.size());
-
-        Assertions.assertFalse(set.contains(different));
-        set.add(different);
-        Assertions.assertEquals(2, set.size());
-
-
+    @Override
+    protected Collection<ChessPosition> buildAllDifferent() {
+        return List.of(
+                new ChessPosition(7, 3),
+                new ChessPosition(6, 3),
+                new ChessPosition(4, 3),
+                new ChessPosition(3, 1),
+                new ChessPosition(3, 2),
+                new ChessPosition(3, 3)
+        );
     }
 
 }

--- a/shared/src/test/java/passoff/chess/ChessPositionTests.java
+++ b/shared/src/test/java/passoff/chess/ChessPositionTests.java
@@ -37,7 +37,7 @@ public class ChessPositionTests {
     }
 
     @Test
-    @DisplayName("Combined Testing")
+    @DisplayName("Equals & HashCode Testing")
     public void hashSetTest() {
         Set<ChessPosition> set = new HashSet<>();
         set.add(original);

--- a/shared/src/test/java/passoff/chess/EqualsTestingUtility.java
+++ b/shared/src/test/java/passoff/chess/EqualsTestingUtility.java
@@ -9,42 +9,58 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Used indirectly to help test the <pre>equals()</pre> and
+ * <pre>hashCode()</pre> methods of other classes.
+ * <br>
+ * This class requires that implementing classes provide a few builder methods,
+ * and then it automatically adds multiple tests to the evaluation suite
+ * which assert that the <pre>equals()</pre> and <pre>hashCode()</pre> methods function.
+ *
+ * @param <T> The type to be compared during testing.
+ */
 public abstract class EqualsTestingUtility<T> {
-    private String itemsPlural;
+    private final String className;
+    private final String itemsPlural;
     private T original;
-    private T equal;
+    private T equivalent;
     private Collection<T> allDifferent;
 
-    protected abstract String getItemsPlural();
+    public EqualsTestingUtility(String className, String itemsPlural) {
+        this.className = className;
+        this.itemsPlural = itemsPlural;
+    }
+
     protected abstract T buildOriginal();
     protected abstract Collection<T> buildAllDifferent();
 
 
     @BeforeEach
     public void setUp() {
-        itemsPlural = getItemsPlural();
         original = buildOriginal();
-        equal = buildOriginal(); // For a second time
+        equivalent = buildOriginal(); // For a second time
         allDifferent = buildAllDifferent();
     }
 
     @Test
     @DisplayName("Equals Testing")
     public void equalsTest() {
-        Assertions.assertEquals(original, equal, "equals returned false for equal " + itemsPlural);
+        Assertions.assertEquals(original, equivalent,
+                className + ".equals() returned false for equivalent " + itemsPlural);
         for (var different : allDifferent) {
-            Assertions.assertNotEquals(original, different, "equals returned true for different " + itemsPlural);
+            Assertions.assertNotEquals(original, different,
+                    className + ".equals() returned true for different " + itemsPlural);
         }
     }
 
     @Test
     @DisplayName("HashCode Testing")
     public void hashTest() {
-        Assertions.assertEquals(original.hashCode(), equal.hashCode(),
-                "hashCode returned different values for equal " + itemsPlural);
+        Assertions.assertEquals(original.hashCode(), equivalent.hashCode(),
+                className + ".hashCode() returned different values for equivalent " + itemsPlural);
         for (var different : allDifferent) {
             Assertions.assertNotEquals(original.hashCode(), different.hashCode(),
-                    "hashCode returned the same value for different " + itemsPlural);
+                    className + ".hashCode() returned the same value for different " + itemsPlural);
         }
     }
 
@@ -55,21 +71,25 @@ public abstract class EqualsTestingUtility<T> {
         set.add(original);
 
         // Manually test insertion of original & equal items
-        Assertions.assertTrue(set.contains(original));
-        Assertions.assertTrue(set.contains(equal));
-        Assertions.assertEquals(1, set.size());
-        set.add(equal);
-        Assertions.assertEquals(1, set.size());
+        Assertions.assertTrue(set.contains(original),
+                "[" + className + "] Original item should exist in collection after adding original item");
+        Assertions.assertTrue(set.contains(equivalent),
+                "[" + className + "] Equivalent item should exist in collection after only adding original item");
+        Assertions.assertEquals(1, set.size(),
+                "[" + className + "] Collection should contain only 1 item after a single insert");
+        set.add(equivalent);
+        Assertions.assertEquals(1, set.size(),
+                "[" + className + "] Collection should still contain only 1 item after adding equivalent item");
 
         // Programmatically test insertion of all different items
         int expectedSetSize = 1;
         for (var different : allDifferent) {
             Assertions.assertFalse(set.contains(different),
-                    "Different item should not be present in set before insertion");
+                    "[" + className + "] Different item should not be present in set before insertion");
             set.add(different);
             expectedSetSize++;
             Assertions.assertEquals(expectedSetSize, set.size(),
-                    "New item was counted as different during insertion");
+                    "[" + className + "] New item was counted as different during insertion");
         }
 
     }

--- a/shared/src/test/java/passoff/chess/EqualsTestingUtility.java
+++ b/shared/src/test/java/passoff/chess/EqualsTestingUtility.java
@@ -1,0 +1,78 @@
+package passoff.chess;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class EqualsTestingUtility<T> {
+    private String itemsPlural;
+    private T original;
+    private T equal;
+    private Collection<T> allDifferent;
+
+    protected abstract String getItemsPlural();
+    protected abstract T getOriginal();
+    protected abstract T getEqual();
+    protected abstract Collection<T> getAllDifferent();
+
+
+    @BeforeEach
+    public void setUp() {
+        itemsPlural = getItemsPlural();
+        original = getOriginal();
+        equal = getEqual();
+        allDifferent = getAllDifferent();
+    }
+
+    @Test
+    @DisplayName("Equals Testing")
+    public void equalsTest() {
+        Assertions.assertEquals(original, equal, "equals returned false for equal " + itemsPlural);
+        for (var different : allDifferent) {
+            Assertions.assertNotEquals(original, different, "equals returned true for different " + itemsPlural);
+        }
+    }
+
+    @Test
+    @DisplayName("HashCode Testing")
+    public void hashTest() {
+        Assertions.assertEquals(original.hashCode(), equal.hashCode(),
+                "hashCode returned different values for equal " + itemsPlural);
+        for (var different : allDifferent) {
+            Assertions.assertNotEquals(original.hashCode(), different.hashCode(),
+                    "hashCode returned the same value for different " + itemsPlural);
+        }
+    }
+
+    @Test
+    @DisplayName("Equals & HashCode Testing")
+    public void hashSetTest() {
+        Set<T> set = new HashSet<>();
+        set.add(original);
+
+        // Manually test insertion of original & equal items
+        Assertions.assertTrue(set.contains(original));
+        Assertions.assertTrue(set.contains(equal));
+        Assertions.assertEquals(1, set.size());
+        set.add(equal);
+        Assertions.assertEquals(1, set.size());
+
+        // Programmatically test insertion of all different items
+        int expectedSetSize = 1;
+        for (var different : allDifferent) {
+            Assertions.assertFalse(set.contains(different),
+                    "Different item should not be present in set before insertion");
+            set.add(different);
+            expectedSetSize++;
+            Assertions.assertEquals(expectedSetSize, set.size(),
+                    "New item was counted as different during insertion");
+        }
+
+    }
+
+}

--- a/shared/src/test/java/passoff/chess/EqualsTestingUtility.java
+++ b/shared/src/test/java/passoff/chess/EqualsTestingUtility.java
@@ -16,17 +16,16 @@ public abstract class EqualsTestingUtility<T> {
     private Collection<T> allDifferent;
 
     protected abstract String getItemsPlural();
-    protected abstract T getOriginal();
-    protected abstract T getEqual();
-    protected abstract Collection<T> getAllDifferent();
+    protected abstract T buildOriginal();
+    protected abstract Collection<T> buildAllDifferent();
 
 
     @BeforeEach
     public void setUp() {
         itemsPlural = getItemsPlural();
-        original = getOriginal();
-        equal = getEqual();
-        allDifferent = getAllDifferent();
+        original = buildOriginal();
+        equal = buildOriginal(); // For a second time
+        allDifferent = buildAllDifferent();
     }
 
     @Test

--- a/shared/src/test/java/passoff/chess/piecemoves/BishopMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piecemoves/BishopMoveTests.java
@@ -1,4 +1,4 @@
-package passoff.chess.piece;
+package passoff.chess.piecemoves;
 
 import chess.ChessPosition;
 import org.junit.jupiter.api.Test;

--- a/shared/src/test/java/passoff/chess/piecemoves/KingMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piecemoves/KingMoveTests.java
@@ -1,62 +1,52 @@
-package passoff.chess.piece;
+package passoff.chess.piecemoves;
 
 import chess.ChessPosition;
 import org.junit.jupiter.api.Test;
 import passoff.chess.TestUtilities;
 
-public class RookMoveTests {
+public class KingMoveTests {
 
     @Test
-    public void rookMoveUntilEdge() {
-
+    public void kingMiddleOfBoard() {
         TestUtilities.validateMoves("""
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
+                        | | | | | |K| | |
                         | | | | | | | | |
-                        | | |R| | | | | |
                         | | | | | | | | |
                         """,
-                new ChessPosition(2, 3),
-                new int[][]{
-                        {2, 4}, {2, 5}, {2, 6}, {2, 7}, {2, 8},
-                        {2, 2}, {2, 1},
-                        {1, 3},
-                        {3, 3}, {4, 3}, {5, 3}, {6, 3}, {7, 3}, {8, 3},
-                }
+                new ChessPosition(3, 6),
+                new int[][]{{4, 6}, {4, 7}, {3, 7}, {2, 7}, {2, 6}, {2, 5}, {3, 5}, {4, 5}}
         );
     }
 
 
     @Test
-    public void rookCaptureEnemy() {
+    public void kingCaptureEnemy() {
         TestUtilities.validateMoves("""
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
-                        |N| | | | | | | |
-                        |r| | | | |B| | |
                         | | | | | | | | |
-                        |q| | | | | | | |
+                        | | | |N|n| | | |
+                        | | | |k| | | | |
+                        | | |P|b|p| | | |
                         | | | | | | | | |
                         """,
-                new ChessPosition(4, 1),
-                new int[][]{
-                        {5, 1},
-                        {3, 1},
-                        {4, 2}, {4, 3}, {4, 4}, {4, 5}, {4, 6},
-                }
+                new ChessPosition(3, 4),
+                new int[][]{{4, 4}, {3, 5}, {2, 3}, {3, 3}, {4, 3}}
         );
     }
 
 
     @Test
-    public void rookBlocked() {
+    public void kingBlocked() {
         TestUtilities.validateMoves("""
-                        | | | | | | |n|r|
-                        | | | | | | | |p|
+                        | | | | | | |r|k|
+                        | | | | | | |p|p|
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |

--- a/shared/src/test/java/passoff/chess/piecemoves/KnightMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piecemoves/KnightMoveTests.java
@@ -1,4 +1,4 @@
-package passoff.chess.piece;
+package passoff.chess.piecemoves;
 
 import chess.ChessPosition;
 import org.junit.jupiter.api.Test;

--- a/shared/src/test/java/passoff/chess/piecemoves/PawnMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piecemoves/PawnMoveTests.java
@@ -1,4 +1,4 @@
-package passoff.chess.piece;
+package passoff.chess.piecemoves;
 
 import chess.ChessMove;
 import chess.ChessPiece;

--- a/shared/src/test/java/passoff/chess/piecemoves/QueenMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piecemoves/QueenMoveTests.java
@@ -1,4 +1,4 @@
-package passoff.chess.piece;
+package passoff.chess.piecemoves;
 
 import chess.ChessPosition;
 import org.junit.jupiter.api.Test;

--- a/shared/src/test/java/passoff/chess/piecemoves/RookMoveTests.java
+++ b/shared/src/test/java/passoff/chess/piecemoves/RookMoveTests.java
@@ -1,52 +1,62 @@
-package passoff.chess.piece;
+package passoff.chess.piecemoves;
 
 import chess.ChessPosition;
 import org.junit.jupiter.api.Test;
 import passoff.chess.TestUtilities;
 
-public class KingMoveTests {
+public class RookMoveTests {
 
     @Test
-    public void kingMiddleOfBoard() {
+    public void rookMoveUntilEdge() {
+
         TestUtilities.validateMoves("""
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
-                        | | | | | |K| | |
                         | | | | | | | | |
+                        | | |R| | | | | |
                         | | | | | | | | |
                         """,
-                new ChessPosition(3, 6),
-                new int[][]{{4, 6}, {4, 7}, {3, 7}, {2, 7}, {2, 6}, {2, 5}, {3, 5}, {4, 5}}
+                new ChessPosition(2, 3),
+                new int[][]{
+                        {2, 4}, {2, 5}, {2, 6}, {2, 7}, {2, 8},
+                        {2, 2}, {2, 1},
+                        {1, 3},
+                        {3, 3}, {4, 3}, {5, 3}, {6, 3}, {7, 3}, {8, 3},
+                }
         );
     }
 
 
     @Test
-    public void kingCaptureEnemy() {
+    public void rookCaptureEnemy() {
         TestUtilities.validateMoves("""
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |
+                        |N| | | | | | | |
+                        |r| | | | |B| | |
                         | | | | | | | | |
-                        | | | |N|n| | | |
-                        | | | |k| | | | |
-                        | | |P|b|p| | | |
+                        |q| | | | | | | |
                         | | | | | | | | |
                         """,
-                new ChessPosition(3, 4),
-                new int[][]{{4, 4}, {3, 5}, {2, 3}, {3, 3}, {4, 3}}
+                new ChessPosition(4, 1),
+                new int[][]{
+                        {5, 1},
+                        {3, 1},
+                        {4, 2}, {4, 3}, {4, 4}, {4, 5}, {4, 6},
+                }
         );
     }
 
 
     @Test
-    public void kingBlocked() {
+    public void rookBlocked() {
         TestUtilities.validateMoves("""
-                        | | | | | | |r|k|
-                        | | | | | | |p|p|
+                        | | | | | | |n|r|
+                        | | | | | | | |p|
                         | | | | | | | | |
                         | | | | | | | | |
                         | | | | | | | | |


### PR DESCRIPTION
## Key Points
- **This PR does _not_ change any requirements.** It refactors duplication out of the tests.
- This PR does make explicit an otherwise implicit requirement: that `ChessBoard` have be able to pass `equals()` and `hashCode()` testing. Previously, these tests were omitted, but a student couldn't pass the course without providing the functionality.
- These improved tests would have clarified a tricky condition where a student was passing all tests locally, but not on the autograder. The same code on these expanded tests failed locally.

## Overview

Add new `ChessPieceTests` which highlight the need for students to provide `equals()` and `hashCode()` methods for the class. This also refactors equals/hashcode testing generally to remove duplicate and rely on a shared code base. The addition of these tests to `ChessBoard` came nearly for free.

## Discussion

This PR moves & changes the "Piece Moves on All Pieces" into the `ChessPieceTests` file.

See the [screenshots in the comments](https://github.com/softwareconstruction240/chess/pull/16#issuecomment-2639024147) about how this solved a tricky problem for a student.

Resolves #11.
