### PR TITLE
Chess board test improvements

### DIFF
--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -18,6 +18,50 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
         super("ChessBoard", "boards");
     }
 
+    @Test
+    @DisplayName("Construct Empty ChessBoard")
+    public void constructChessBoard() {
+        ChessBoard board = new ChessBoard();
+
+        for (int row = 1; row <= 8; row++) {
+            for (int col = 1; col <= 8; col++) {
+                Assertions.assertNull(
+                        board.getPiece(new ChessPosition(row, col)),
+                        "Immediately upon construction, a ChessBoard should be empty."
+                );
+            }
+        }
+
+    }
+
+    @Test
+    @DisplayName("Add and Get Piece")
+    public void getAddPiece() {
+        ChessPosition position = new ChessPosition(4, 4);
+        ChessPiece piece = new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.BISHOP);
+
+        var board = new ChessBoard();
+        board.addPiece(position, piece);
+
+        ChessPiece foundPiece = board.getPiece(position);
+
+        Assertions.assertEquals(piece.getPieceType(), foundPiece.getPieceType(),
+                "ChessPiece returned by getPiece had the wrong piece type");
+        Assertions.assertEquals(piece.getTeamColor(), foundPiece.getTeamColor(),
+                "ChessPiece returned by getPiece had the wrong team color");
+    }
+
+    @Test
+    @DisplayName("Reset Board")
+    public void defaultGameBoard() {
+        var expectedBoard = TestUtilities.defaultBoard();
+
+        var actualBoard = new ChessBoard();
+        actualBoard.resetBoard();
+
+        Assertions.assertEquals(expectedBoard, actualBoard);
+    }
+
     @Override
     protected ChessBoard buildOriginal() {
         var basicBoard = new ChessBoard();
@@ -68,51 +112,6 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
         board.addPiece(position, piece);
 
         return board;
-    }
-
-    @Test
-    @DisplayName("Construct Empty ChessBoard")
-    public void constructChessBoard() {
-        ChessBoard board = new ChessBoard();
-
-        for (int row = 1; row <= 8; row++) {
-            for (int col = 1; col <= 8; col++) {
-                Assertions.assertNull(
-                        board.getPiece(new ChessPosition(row, col)),
-                        "Immediately upon construction, a ChessBoard should be empty."
-                );
-            }
-        }
-
-    }
-
-    @Test
-    @DisplayName("Add and Get Piece")
-    public void getAddPiece() {
-        ChessPosition position = new ChessPosition(4, 4);
-        ChessPiece piece = new ChessPiece(ChessGame.TeamColor.BLACK, ChessPiece.PieceType.BISHOP);
-
-        var board = new ChessBoard();
-        board.addPiece(position, piece);
-
-        ChessPiece foundPiece = board.getPiece(position);
-
-        Assertions.assertEquals(piece.getPieceType(), foundPiece.getPieceType(),
-                "ChessPiece returned by getPiece had the wrong piece type");
-        Assertions.assertEquals(piece.getTeamColor(), foundPiece.getTeamColor(),
-                "ChessPiece returned by getPiece had the wrong team color");
-    }
-
-
-    @Test
-    @DisplayName("Reset Board")
-    public void defaultGameBoard() {
-        var expectedBoard = TestUtilities.defaultBoard();
-
-        var actualBoard = new ChessBoard();
-        actualBoard.resetBoard();
-
-        Assertions.assertEquals(expectedBoard, actualBoard);
     }
 
 }

--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -73,6 +73,22 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
     }
 
     @Test
+    @DisplayName("Construct Empty ChessBoard")
+    public void constructChessBoard() {
+        ChessBoard board = new ChessBoard();
+
+        for (int row = 1; row <= 8; row++) {
+            for (int col = 1; col <= 8; col++) {
+                Assertions.assertNull(
+                        board.getPiece(new ChessPosition(row, col)),
+                        "Immediately upon construction, a ChessBoard should be empty."
+                );
+            }
+        }
+
+    }
+
+    @Test
     @DisplayName("Add and Get Piece")
     public void getAddPiece() {
         ChessPosition position = new ChessPosition(4, 4);

--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Random;
 
 public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
     public ChessBoardTests() {
@@ -75,38 +74,31 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
 
         differentBoards.add(new ChessBoard()); // An empty board
 
-        // Generate boards each with one random piece added an edge or the primary diagonal
-        /*
-        Each 'X' is a different default board that will be tested.
+        ChessPiece.PieceType[] pieceSchedule = {
+                ChessPiece.PieceType.ROOK, ChessPiece.PieceType.KNIGHT,
+                ChessPiece.PieceType.BISHOP, ChessPiece.PieceType.QUEEN,
+                ChessPiece.PieceType.KING, ChessPiece.PieceType.PAWN,
+                ChessPiece.PieceType.KING, ChessPiece.PieceType.ROOK,
+        };
 
-                |X| | | | | | |X|
-                |X| | | | | |X| |
-                |X| | | | |X| | |
-                |X| | | |X| | | |
-                |X| | |X| | | | |
-                |X| |X| | | | | |
-                |X|X| | | | | | |
-                |X|X|X|X|X|X|X|X|
-         */
-        Random random = new Random();
-        for (int i = 1; i <= 8; i++) {
-            differentBoards.add(createBoardWithRandomPieceAddedInPosition(i, i, random));
-            if (i != 1) {
-                differentBoards.add(createBoardWithRandomPieceAddedInPosition(1, i, random));
-                differentBoards.add(createBoardWithRandomPieceAddedInPosition(i, 1, random));
+        // Generate boards each with one piece added from a static list.
+        // The color is assigned in a mixed pattern.
+        boolean isWhite;
+        for (int col = 1; col <= 8; col++) {
+            for (int row = 1; row <= 8; row++) {
+                isWhite = (row + col) % 2 == 0;
+                differentBoards.add(createBoardWithPiece(row, col, pieceSchedule[row], isWhite));
             }
         }
 
         return differentBoards;
     }
 
-    private ChessBoard createBoardWithRandomPieceAddedInPosition(int row, int col, Random random) {
+    private ChessBoard createBoardWithPiece(int row, int col, ChessPiece.PieceType type, boolean isWhite) {
         var board = new ChessBoard();
 
-        var pieceTypes = List.of(ChessPiece.PieceType.values());
-        var randomPieceType = pieceTypes.get(random.nextInt(pieceTypes.size()));
-        var randomTeamColor = random.nextBoolean() ? ChessGame.TeamColor.WHITE : ChessGame.TeamColor.BLACK;
-        var piece = new ChessPiece(randomTeamColor, randomPieceType);
+        var teamColor = isWhite ? ChessGame.TeamColor.WHITE : ChessGame.TeamColor.BLACK;
+        var piece = new ChessPiece(teamColor, type);
 
         var position = new ChessPosition(row, col);
         board.addPiece(position, piece);

--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 
 public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
     public ChessBoardTests() {
@@ -25,9 +27,49 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
 
     @Override
     protected Collection<ChessBoard> buildAllDifferent() {
-        return List.of(
-                new ChessBoard() // Empty
-        );
+        List<ChessBoard> differentBoards = new ArrayList<>();
+
+        differentBoards.add(new ChessBoard()); // An empty board
+
+        // Generate boards with random pieces added along some edges and primary diagonal
+        /*
+        Each 'X' is a different default board that will be tested.
+        Each 's' represents a starting piece after calling resetBoard().
+
+                |X|s|s|s|s|s|s|X|
+                |X|s|s|s|s|s|X|s|
+                |X| | | | |X| | |
+                |X| | | |X| | | |
+                |X| | |X| | | | |
+                |X| |X| | | | | |
+                |X|X|s|s|s|s|s|s|
+                |X|X|X|X|X|X|X|X|
+         */
+        Random random = new Random();
+        for (int i = 1; i <= 8; i++) {
+            differentBoards.add(createDefaultBoardWithRandomPieceAddedInPosition(i, i, random));
+            if (i != 1) {
+                differentBoards.add(createDefaultBoardWithRandomPieceAddedInPosition(1, i, random));
+                differentBoards.add(createDefaultBoardWithRandomPieceAddedInPosition(i, 1, random));
+            }
+        }
+
+        return differentBoards;
+    }
+
+    private ChessBoard createDefaultBoardWithRandomPieceAddedInPosition(int row, int col, Random random) {
+        var board = new ChessBoard();
+        board.resetBoard();
+
+        var pieceTypes = List.of(ChessPiece.PieceType.values());
+        var randomPieceType = pieceTypes.get(random.nextInt(pieceTypes.size()));
+        var randomTeamColor = random.nextBoolean() ? ChessGame.TeamColor.WHITE : ChessGame.TeamColor.BLACK;
+        var piece = new ChessPiece(randomTeamColor, randomPieceType);
+
+        var position = new ChessPosition(row, col);
+        board.addPiece(position, piece);
+
+        return board;
     }
 
     @Test

--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -83,11 +83,13 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
 
         // Generate boards each with one piece added from a static list.
         // The color is assigned in a mixed pattern.
+        ChessPiece.PieceType type;
         boolean isWhite;
         for (int col = 1; col <= 8; col++) {
             for (int row = 1; row <= 8; row++) {
+                type = pieceSchedule[row-1];
                 isWhite = (row + col) % 2 == 0;
-                differentBoards.add(createBoardWithPiece(row, col, pieceSchedule[row], isWhite));
+                differentBoards.add(createBoardWithPiece(row, col, type, isWhite));
             }
         }
 

--- a/shared/src/test/java/passoff/chess/ChessBoardTests.java
+++ b/shared/src/test/java/passoff/chess/ChessBoardTests.java
@@ -31,35 +31,33 @@ public class ChessBoardTests extends EqualsTestingUtility<ChessBoard> {
 
         differentBoards.add(new ChessBoard()); // An empty board
 
-        // Generate boards with random pieces added along some edges and primary diagonal
+        // Generate boards each with one random piece added an edge or the primary diagonal
         /*
         Each 'X' is a different default board that will be tested.
-        Each 's' represents a starting piece after calling resetBoard().
 
-                |X|s|s|s|s|s|s|X|
-                |X|s|s|s|s|s|X|s|
+                |X| | | | | | |X|
+                |X| | | | | |X| |
                 |X| | | | |X| | |
                 |X| | | |X| | | |
                 |X| | |X| | | | |
                 |X| |X| | | | | |
-                |X|X|s|s|s|s|s|s|
+                |X|X| | | | | | |
                 |X|X|X|X|X|X|X|X|
          */
         Random random = new Random();
         for (int i = 1; i <= 8; i++) {
-            differentBoards.add(createDefaultBoardWithRandomPieceAddedInPosition(i, i, random));
+            differentBoards.add(createBoardWithRandomPieceAddedInPosition(i, i, random));
             if (i != 1) {
-                differentBoards.add(createDefaultBoardWithRandomPieceAddedInPosition(1, i, random));
-                differentBoards.add(createDefaultBoardWithRandomPieceAddedInPosition(i, 1, random));
+                differentBoards.add(createBoardWithRandomPieceAddedInPosition(1, i, random));
+                differentBoards.add(createBoardWithRandomPieceAddedInPosition(i, 1, random));
             }
         }
 
         return differentBoards;
     }
 
-    private ChessBoard createDefaultBoardWithRandomPieceAddedInPosition(int row, int col, Random random) {
+    private ChessBoard createBoardWithRandomPieceAddedInPosition(int row, int col, Random random) {
         var board = new ChessBoard();
-        board.resetBoard();
 
         var pieceTypes = List.of(ChessPiece.PieceType.values());
         var randomPieceType = pieceTypes.get(random.nextInt(pieceTypes.size()));

--- a/shared/src/test/java/passoff/chess/ChessMoveTests.java
+++ b/shared/src/test/java/passoff/chess/ChessMoveTests.java
@@ -33,5 +33,4 @@ public class ChessMoveTests extends EqualsTestingUtility<ChessMove> {
         );
     }
 
-
 }


### PR DESCRIPTION
## Key Points

- **This PR does not change any course requirements.** The `ChessBoard` class has always required `equals()` and `hashCode()` testing; however, these tests were previously not explicit. Students would fail without good implementation, but the symptoms were unclear.
- This PR only adds additional tests which better evaluate existing requirements.
- These new tests have been tested against functioning code.

## Overview

Improve comprehensiveness and make ChessBoard tests more understandable by adding specific tests for requirements that students would otherwise discover late.

## Discussion

It oftentimes takes students a long time to realize that a `new ChessBoard()` cannot call `resetBoard()` automatically. While this isn't the place to explain _why_ this is the case, we can point out the requirement explicitly.

This test uses some randomness while testing the hashCodes of `ChessBoard`. This randomness reduces the total number of evaluations required, but still emphasizes the overall requirement of the test. I think it was fun to create the tests.

## Dependencies

- ~This is intended to be merged **after** #16.~
    - Actually, it doesn't matter much which order these PRs are merged.
    - It would be better to merge #16 first since then both merge commits end up on the same branch, but it will be fine either way.
    - I mostly just wanted to raise these issues separate from the improvements provided in the base PR.

## Work List
- [x] Run working implementation through revamped test cases

## Help Requested

@Maillman Can you please run your code through these tests? This branch also includes the changes in #16.