### PR TITLE
Edit DatabaseManager.java to improve try blocks and documentation

### DIFF
--- a/starter-code/3-web-api/dataaccess/DataAccessException.java
+++ b/starter-code/3-web-api/dataaccess/DataAccessException.java
@@ -4,6 +4,9 @@ package dataaccess;
  * Indicates there was an error connecting to the database
  */
 public class DataAccessException extends Exception{
+    public DataAccessException(String message) {
+        super(message);
+    }
     public DataAccessException(String message, Throwable ex) {
         super(message, ex);
     }

--- a/starter-code/3-web-api/dataaccess/DataAccessException.java
+++ b/starter-code/3-web-api/dataaccess/DataAccessException.java
@@ -4,7 +4,7 @@ package dataaccess;
  * Indicates there was an error connecting to the database
  */
 public class DataAccessException extends Exception{
-    public DataAccessException(String message) {
-        super(message);
+    public DataAccessException(String message, Throwable ex) {
+        super(message, ex);
     }
 }

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -15,7 +15,7 @@ public class DatabaseManager {
     static {
         try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
             if (propStream == null) {
-                throw new Exception("file could not be found");
+                throw new Exception("file \"db.properties\" could not be found");
             }
             Properties props = new Properties();
             props.load(propStream);

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -35,12 +35,10 @@ public class DatabaseManager {
      * Creates the database if it does not already exist.
      */
     static void createDatabase() throws DataAccessException {
-        try {
-            var statement = "CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME;
-            var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
-            try (var preparedStatement = conn.prepareStatement(statement)) {
+        var statement = "CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME;
+        try(var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
+            var preparedStatement = conn.prepareStatement(statement)) {
                 preparedStatement.executeUpdate();
-            }
         } catch (SQLException e) {
             throw new DataAccessException(e.getMessage());
         }

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -51,7 +51,7 @@ public class DatabaseManager {
      * The easiest way to do that is with a try-with-resource block.
      * <br/>
      * <code>
-     * try (var conn = DatabaseManager.getConnection(databaseName)) {
+     * try (var conn = DatabaseManager.getConnection()) {
      * // execute SQL statements.
      * }
      * </code>

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -15,7 +15,7 @@ public class DatabaseManager {
     static {
         try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
             if (propStream == null) {
-                throw new Exception("file \"db.properties\" could not be found");
+                throw new Exception("file could not be found");
             }
             Properties props = new Properties();
             props.load(propStream);

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -58,7 +58,7 @@ public class DatabaseManager {
      */
     static Connection getConnection() throws DataAccessException {
         try {
-            //wrapping this line with a try-with-resources block will return a closed connection
+            //do not wrap the following line with a try-with-resources
             var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
             conn.setCatalog(DATABASE_NAME);
             return conn;

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -55,7 +55,7 @@ public class DatabaseManager {
      * The easiest way to do that is with a try-with-resource block.
      * <br/>
      * <code>
-     * try (var conn = DbInfo.getConnection(databaseName)) {
+     * try (var conn = DatabaseManager.getConnection(databaseName)) {
      * // execute SQL statements.
      * }
      * </code>

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -34,7 +34,7 @@ public class DatabaseManager {
     /**
      * Creates the database if it does not already exist.
      */
-    static void createDatabase() throws DataAccessException {
+    static public void createDatabase() throws DataAccessException {
         var statement = "CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME;
         try(var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
             var preparedStatement = conn.prepareStatement(statement)) {

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -15,7 +15,7 @@ public class DatabaseManager {
     static {
         try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
             if (propStream == null) {
-                throw new Exception("Unable to load db.properties");
+                throw new Exception("file could not be found");
             }
             Properties props = new Properties();
             props.load(propStream);
@@ -27,7 +27,7 @@ public class DatabaseManager {
             var port = Integer.parseInt(props.getProperty("db.port"));
             CONNECTION_URL = String.format("jdbc:mysql://%s:%d", host, port);
         } catch (Exception ex) {
-            throw new RuntimeException("unable to process db.properties. " + ex.getMessage());
+            throw new RuntimeException("unable to process db.properties", ex);
         }
     }
 
@@ -39,8 +39,8 @@ public class DatabaseManager {
         try (var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
              var preparedStatement = conn.prepareStatement(statement)) {
             preparedStatement.executeUpdate();
-        } catch (SQLException e) {
-            throw new DataAccessException("Failed to create database", e);
+        } catch (SQLException ex) {
+            throw new DataAccessException("failed to create database", ex);
         }
     }
 
@@ -62,8 +62,8 @@ public class DatabaseManager {
             var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
             conn.setCatalog(DATABASE_NAME);
             return conn;
-        } catch (SQLException e) {
-            throw new DataAccessException("Failed to get connection", e);
+        } catch (SQLException ex) {
+            throw new DataAccessException("failed to get connection", ex);
         }
     }
 }

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -36,9 +36,9 @@ public class DatabaseManager {
      */
     static public void createDatabase() throws DataAccessException {
         var statement = "CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME;
-        try(var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
-            var preparedStatement = conn.prepareStatement(statement)) {
-                preparedStatement.executeUpdate();
+        try (var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
+             var preparedStatement = conn.prepareStatement(statement)) {
+            preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new DataAccessException(e.getMessage());
         }

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -58,6 +58,7 @@ public class DatabaseManager {
      */
     static Connection getConnection() throws DataAccessException {
         try {
+            //wrapping this line with a try-with-resources block will return a closed connection
             var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
             conn.setCatalog(DATABASE_NAME);
             return conn;

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -40,7 +40,7 @@ public class DatabaseManager {
              var preparedStatement = conn.prepareStatement(statement)) {
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            throw new DataAccessException(e.getMessage());
+            throw new DataAccessException("Failed to create database", e);
         }
     }
 
@@ -63,7 +63,7 @@ public class DatabaseManager {
             conn.setCatalog(DATABASE_NAME);
             return conn;
         } catch (SQLException e) {
-            throw new DataAccessException(e.getMessage());
+            throw new DataAccessException("Failed to get connection", e);
         }
     }
 }

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -13,21 +13,19 @@ public class DatabaseManager {
      * Load the database information for the db.properties file.
      */
     static {
-        try {
-            try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
-                if (propStream == null) {
-                    throw new Exception("Unable to load db.properties");
-                }
-                Properties props = new Properties();
-                props.load(propStream);
-                DATABASE_NAME = props.getProperty("db.name");
-                USER = props.getProperty("db.user");
-                PASSWORD = props.getProperty("db.password");
-
-                var host = props.getProperty("db.host");
-                var port = Integer.parseInt(props.getProperty("db.port"));
-                CONNECTION_URL = String.format("jdbc:mysql://%s:%d", host, port);
+        try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
+            if (propStream == null) {
+                throw new Exception("Unable to load db.properties");
             }
+            Properties props = new Properties();
+            props.load(propStream);
+            DATABASE_NAME = props.getProperty("db.name");
+            USER = props.getProperty("db.user");
+            PASSWORD = props.getProperty("db.password");
+
+            var host = props.getProperty("db.host");
+            var port = Integer.parseInt(props.getProperty("db.port"));
+            CONNECTION_URL = String.format("jdbc:mysql://%s:%d", host, port);
         } catch (Exception ex) {
             throw new RuntimeException("unable to process db.properties. " + ex.getMessage());
         }


### PR DESCRIPTION
This PR fixes issues with documentation and JDBC connections that were left open in the code. These issues were discussed in a TA meeting. When reviewing, please make sure the style of the try-with-resources is correctly implemented. 

In addition to this, I made two changes that were not discussed in the meeting. The first was making the createDatabase method public since most students end up using this function in their Server class and making it public anyway. 

The second is a code comment in the getConnection method warning students not to use a try-with-resources _inside_ this method or the whole function will return a closed connection--which would not work.