### PR TITLE
Improve WebSocket Tests Error Messages

### DIFF
--- a/starter-code/6-gameplay/passoff/server/WebSocketTests.java
+++ b/starter-code/6-gameplay/passoff/server/WebSocketTests.java
@@ -63,7 +63,7 @@ public class WebSocketTests {
     @Order(1)
     @DisplayName("Connect 1 User")
     public void connectSingleUser() {
-        connectToGame(white, gameID, true, Set.of(), Set.of()); //Connects 1 User to the game
+        connectToGame(white, gameID, true, Set.of(), Set.of(), "white player connect");
     }
 
     @Test
@@ -77,16 +77,15 @@ public class WebSocketTests {
     @Order(3)
     @DisplayName("Connect Bad GameID")
     public void connectBadGameID() {
-        connectToGame(white, gameID + 1, false, Set.of(), Set.of()); //player connect with an incorrect game id
-        connectToGame(observer, gameID + 1, false, Set.of(white), Set.of()); //observer incorrect game id
+        connectToGame(white, gameID + 1, false, Set.of(), Set.of(), "player connect with wrong id");
+        connectToGame(observer, gameID + 1, false, Set.of(white), Set.of(), "observer connect with wrong id");
     }
 
     @Test
     @Order(3)
     @DisplayName("Connect Bad AuthToken")
     public void connectBadAuthToken() {
-        connectToGame(new WebsocketUser(black.username(), "badAuth"), gameID, false, Set.of(), Set.of());
-        connectToGame(new WebsocketUser(observer.username(), "badAuth"), gameID, false, Set.of(black), Set.of());
+        connectToGame(new WebsocketUser("didn't register", "badAuth"), gameID, false, Set.of(), Set.of(), "connect with bad auth");
     }
 
     @Test
@@ -97,7 +96,7 @@ public class WebSocketTests {
 
         //make a valid pawn move
         ChessMove move = new ChessMove(new ChessPosition(2, 5), new ChessPosition(3, 5), null);
-        makeMove(white, gameID, move,true, false, Set.of(black, observer), Set.of());
+        makeMove(white, gameID, move,true, false, Set.of(black, observer), Set.of(), "move made");
     }
 
     @Test
@@ -108,7 +107,8 @@ public class WebSocketTests {
 
         //make valid move command with wrong authtoken
         ChessMove move = new ChessMove(new ChessPosition(2, 6), new ChessPosition(4, 6), null);
-        makeMove(new WebsocketUser(white.username(), "badAuth"), gameID, move, false, false, Set.of(black, observer), Set.of());
+        makeMove(new WebsocketUser(white.username(), "badAuth"), gameID, move, false, false,
+                Set.of(black, observer), Set.of(), "move made with bad authtoken");
     }
 
     @Test
@@ -119,7 +119,7 @@ public class WebSocketTests {
 
         //try to move rook through a pawn - invalid move
         ChessMove move = new ChessMove(new ChessPosition(1, 1), new ChessPosition(1, 5), null);
-        makeMove(white, gameID, move, false, false, Set.of(black, observer), Set.of());
+        makeMove(white, gameID, move, false, false, Set.of(black, observer), Set.of(), "invalid move attempted");
     }
 
     @Test
@@ -130,7 +130,7 @@ public class WebSocketTests {
 
         //try to move pawn out of turn - would be valid if in turn
         ChessMove move = new ChessMove(new ChessPosition(7, 5), new ChessPosition(5, 5), null);
-        makeMove(black, gameID, move, false, false, Set.of(white, observer), Set.of());
+        makeMove(black, gameID, move, false, false, Set.of(white, observer), Set.of(), "move made out of turn");
     }
 
     @Test
@@ -141,7 +141,7 @@ public class WebSocketTests {
 
         //attempt to have black player move white piece
         ChessMove move = new ChessMove(new ChessPosition(2, 5), new ChessPosition(4, 5), null);
-        makeMove(black, gameID, move, false, false, Set.of(white, observer), Set.of());
+        makeMove(black, gameID, move, false, false, Set.of(white, observer), Set.of(), "move made for opponent");
     }
 
     @Test
@@ -152,7 +152,7 @@ public class WebSocketTests {
 
         //have observer attempt to make an otherwise valid move
         ChessMove move = new ChessMove(new ChessPosition(2, 5), new ChessPosition(4, 5), null);
-        makeMove(observer, gameID, move, false, false, Set.of(white, black), Set.of());
+        makeMove(observer, gameID, move, false, false, Set.of(white, black), Set.of(), "observer attempts move");
     }
 
     @Test
@@ -163,16 +163,16 @@ public class WebSocketTests {
 
         //Fools mate setup
         ChessMove move = new ChessMove(new ChessPosition(2, 7), new ChessPosition(4, 7), null);
-        makeMove(white, gameID, move, true, false, Set.of(black, observer), Set.of());
+        makeMove(white, gameID, move, true, false, Set.of(black, observer), Set.of(), "first move");
         move = new ChessMove(new ChessPosition(7, 5), new ChessPosition(6, 5), null);
-        makeMove(black, gameID, move, true, false, Set.of(white, observer), Set.of());
+        makeMove(black, gameID, move, true, false, Set.of(white, observer), Set.of(), "second move");
         move = new ChessMove(new ChessPosition(2, 6), new ChessPosition(3, 6), null);
-        makeMove(white, gameID, move, true, false, Set.of(black, observer), Set.of());
+        makeMove(white, gameID, move, true, false, Set.of(black, observer), Set.of(), "third move");
         move = new ChessMove(new ChessPosition(8, 4), new ChessPosition(4, 8), null);
-        makeMove(black, gameID, move, true, true, Set.of(white, observer), Set.of());
+        makeMove(black, gameID, move, true, true, Set.of(white, observer), Set.of(), "checkmate move");
         //checkmate--attempt another move
         move = new ChessMove(new ChessPosition(2, 5), new ChessPosition(4, 5), null);
-        makeMove(white, gameID, move, false, false, Set.of(black, observer), Set.of());
+        makeMove(white, gameID, move, false, false, Set.of(black, observer), Set.of(), "invalid move");
     }
 
     @Test
@@ -180,7 +180,7 @@ public class WebSocketTests {
     @DisplayName("Normal Resign")
     public void validResign() {
         setupNormalGame();
-        resign(white, gameID, true, Set.of(black, observer), Set.of());
+        resign(white, gameID, true, Set.of(black, observer), Set.of(), "resign");
     }
 
     @Test
@@ -188,11 +188,11 @@ public class WebSocketTests {
     @DisplayName("Cannot Move After Resign")
     public void moveAfterResign() {
         setupNormalGame();
-        resign(black, gameID, true, Set.of(white, observer), Set.of());
+        resign(black, gameID, true, Set.of(white, observer), Set.of(), "resign");
 
         //attempt to make a move after other player resigns
         ChessMove move = new ChessMove(new ChessPosition(2, 5), new ChessPosition(4, 5), null);
-        makeMove(white, gameID, move, false, false, Set.of(black, observer), Set.of());
+        makeMove(white, gameID, move, false, false, Set.of(black, observer), Set.of(), "move after resign");
     }
 
     @Test
@@ -202,7 +202,7 @@ public class WebSocketTests {
         setupNormalGame();
 
         //have observer try to resign - should reject
-        resign(observer, gameID, false, Set.of(white, black), Set.of());
+        resign(observer, gameID, false, Set.of(white, black), Set.of(), "observer resign");
     }
 
     @Test
@@ -210,10 +210,10 @@ public class WebSocketTests {
     @DisplayName("Double Resign")
     public void invalidResignGameOver() {
         setupNormalGame();
-        resign(black, gameID, true, Set.of(white, observer), Set.of());
+        resign(black, gameID, true, Set.of(white, observer), Set.of(), "first resign");
 
         //attempt to resign after other player resigns
-        resign(white, gameID, false, Set.of(black, observer), Set.of());
+        resign(white, gameID, false, Set.of(black, observer), Set.of(), "second resign");
     }
 
     @Test
@@ -223,10 +223,10 @@ public class WebSocketTests {
         setupNormalGame();
 
         //have white player leave--all other players get notified, white player should not be
-        leave(white, gameID, Set.of(black, observer), Set.of());
+        leave(white, gameID, Set.of(black, observer), Set.of(), "player/first leave");
 
         //observer leaves - only black player should get a notification
-        leave(observer, gameID, Set.of(black), Set.of(white));
+        leave(observer, gameID, Set.of(black), Set.of(white), "observer/second leave");
     }
 
     @Test
@@ -236,16 +236,16 @@ public class WebSocketTests {
         setupNormalGame();
 
         //have white player leave--all other players get notified, white player should not be
-        leave(white, gameID, Set.of(black, observer), Set.of());
+        leave(white, gameID, Set.of(black, observer), Set.of(), "normal leave");
 
         //replace white player with a different player
         WebsocketUser white2 = registerUser("white2", "WHITE", "white2@chess.com");
         joinGame(gameID, white2, ChessGame.TeamColor.WHITE);
-        connectToGame(white2, gameID, true, Set.of(black, observer), Set.of(white));
+        connectToGame(white2, gameID, true, Set.of(black, observer), Set.of(white), "connect after leave");
 
         //new white player can make move
         ChessMove move = new ChessMove(new ChessPosition(2, 5), new ChessPosition(3, 5), null);
-        makeMove(white2, gameID, move, true, false, Set.of(black, observer), Set.of(white));
+        makeMove(white2, gameID, move, true, false, Set.of(black, observer), Set.of(white), "new player moves");
     }
 
     @Test
@@ -261,25 +261,25 @@ public class WebSocketTests {
         int otherGameID = createGame(white, "testGame2");
         joinGame(otherGameID, white2, ChessGame.TeamColor.WHITE);
         joinGame(otherGameID, black2, ChessGame.TeamColor.BLACK);
-        connectToGame(white2, otherGameID, true, Set.of(), Set.of(white, black, observer));
-        connectToGame(black2, otherGameID, true, Set.of(white2), Set.of(white, black, observer));
-        connectToGame(observer2, otherGameID, true,  Set.of(white2, black2), Set.of(white, black, observer));
+        connectToGame(white2, otherGameID, true, Set.of(), Set.of(white, black, observer), "connect 1 to other game");
+        connectToGame(black2, otherGameID, true, Set.of(white2), Set.of(white, black, observer), "connect 2 to other game");
+        connectToGame(observer2, otherGameID, true,  Set.of(white2, black2), Set.of(white, black, observer), "connect 3 to other game");
 
         //make move in first game - only users in first game should be notified
         ChessMove move = new ChessMove(new ChessPosition(2, 5), new ChessPosition(3, 5), null);
-        makeMove(white, gameID, move, true, false, Set.of(black, observer), Set.of(white2, black2, observer2));
+        makeMove(white, gameID, move, true, false, Set.of(black, observer), Set.of(white2, black2, observer2), "move from game 1");
 
         //resign in second game - only users in second game should be notified
-        resign(white2, otherGameID, true, Set.of(black2, observer2), Set.of(white, black, observer));
+        resign(white2, otherGameID, true, Set.of(black2, observer2), Set.of(white, black, observer), "resign from game 2");
 
         //player leave in first game - only users remaining in first game should be notified
-        leave(white, gameID, Set.of(black, observer), Set.of(white2, black2, observer2));
+        leave(white, gameID, Set.of(black, observer), Set.of(white2, black2, observer2), "leave from game 1");
     }
 
     private void setupNormalGame() {
-        connectToGame(white, gameID, true, Set.of(), Set.of()); //connect white player
-        connectToGame(black, gameID, true, Set.of(white), Set.of()); //connect black player
-        connectToGame(observer, gameID, true,  Set.of(white, black), Set.of()); //connect observer
+        connectToGame(white, gameID, true, Set.of(), Set.of(), "white player connect");
+        connectToGame(black, gameID, true, Set.of(white), Set.of(), "black player connect");
+        connectToGame(observer, gameID, true,  Set.of(white, black), Set.of(), "observer connect");
     }
 
     private WebsocketUser registerUser(String name, String password, String email) {
@@ -306,48 +306,48 @@ public class WebSocketTests {
     }
 
     private void connectToGame(WebsocketUser sender, int gameID, boolean expectSuccess,
-                               Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients) {
+                               Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients, String description) {
         TestCommand connectCommand = new TestCommand(UserGameCommand.CommandType.CONNECT, sender.authToken(), gameID);
         Map<String, Integer> numExpectedMessages = expectedMessages(sender, 1, inGame, (expectSuccess ? 1 : 0), otherClients);
         Map<String, List<TestMessage>> actualMessages = environment.exchange(sender.username(), connectCommand, numExpectedMessages, waitTime);
 
-        assertCommandMessages(actualMessages, expectSuccess, sender, types(LOAD_GAME), inGame, types(NOTIFICATION), otherClients);
+        assertCommandMessages(actualMessages, expectSuccess, sender, types(LOAD_GAME), inGame, types(NOTIFICATION), otherClients, description);
     }
 
-    private void makeMove(WebsocketUser sender, int gameID, ChessMove move, boolean expectSuccess,
-                          boolean extraNotification, Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients) {
+    private void makeMove(WebsocketUser sender, int gameID, ChessMove move, boolean expectSuccess, boolean extraNotification,
+                          Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients, String description) {
         TestCommand moveCommand = new TestCommand(sender.authToken(), gameID, move);
         Map<String, Integer> numExpectedMessages = expectedMessages(sender, 1, inGame, (expectSuccess ? 2 : 0), otherClients);
         Map<String, List<TestMessage>> actualMessages = environment.exchange(sender.username(), moveCommand, numExpectedMessages, waitTime);
 
         if(extraNotification && actualMessages.get(sender.username()).size() > 1) {
             assertCommandMessages(actualMessages, expectSuccess, sender, types(LOAD_GAME, NOTIFICATION),
-                    inGame, types(LOAD_GAME, NOTIFICATION, NOTIFICATION), otherClients);
+                    inGame, types(LOAD_GAME, NOTIFICATION, NOTIFICATION), otherClients, description);
         }
         else {
             assertCommandMessages(actualMessages, expectSuccess, sender, types(LOAD_GAME),
-                    inGame, types(LOAD_GAME, NOTIFICATION), otherClients);
+                    inGame, types(LOAD_GAME, NOTIFICATION), otherClients, description);
         }
     }
 
     private void resign(WebsocketUser sender, int gameID, boolean expectSuccess,
-                        Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients) {
+                        Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients, String description) {
         TestCommand resignCommand = new TestCommand(UserGameCommand.CommandType.RESIGN, sender.authToken(), gameID);
         Map<String, Integer> numExpectedMessages = expectedMessages(sender, 1, inGame, (expectSuccess ? 1 : 0), otherClients);
         Map<String, List<TestMessage>> actualMessages = environment.exchange(sender.username(), resignCommand, numExpectedMessages, waitTime);
 
         assertCommandMessages(actualMessages, expectSuccess, sender, types(NOTIFICATION),
-                inGame, types(NOTIFICATION), otherClients);
+                inGame, types(NOTIFICATION), otherClients, description);
     }
 
-    private void leave(WebsocketUser sender, int gameID, Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients) {
+    private void leave(WebsocketUser sender, int gameID, Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients, String description) {
         TestCommand leaveCommand = new TestCommand(UserGameCommand.CommandType.LEAVE, sender.authToken(), gameID);
         Map<String, Integer> numExpectedMessages = expectedMessages(sender, 0, inGame, 1, otherClients);
         Map<String, List<TestMessage>> actualMessages = environment.exchange(sender.username(), leaveCommand, numExpectedMessages, waitTime);
 
-        assertCommandMessages(actualMessages, true, sender, types(), inGame, types(NOTIFICATION), otherClients);
+        assertCommandMessages(actualMessages, true, sender, types(), inGame, types(NOTIFICATION), otherClients, description);
     }
-    
+
     private Map<String, Integer> expectedMessages(WebsocketUser sender, int senderExpected,
                                                   Set<WebsocketUser> inGame, int inGameExpected, Set<WebsocketUser> otherClients) {
         Map<String, Integer> expectedMessages = new HashMap<>();
@@ -358,25 +358,25 @@ public class WebSocketTests {
     }
 
     private void assertCommandMessages(Map<String, List<TestMessage>> messages, boolean expectSuccess,
-                                            WebsocketUser user, ServerMessage.ServerMessageType[] userExpectedTypes,
-                                            Set<WebsocketUser> inGame, ServerMessage.ServerMessageType[] inGameExpectedTypes,
-                                            Set<WebsocketUser> otherClients) {
+                                       WebsocketUser user, ServerMessage.ServerMessageType[] userExpectedTypes,
+                                       Set<WebsocketUser> inGame, ServerMessage.ServerMessageType[] inGameExpectedTypes,
+                                       Set<WebsocketUser> otherClients, String description) {
         if(!expectSuccess) {
             userExpectedTypes = new ServerMessage.ServerMessageType[]{ERROR};
             inGameExpectedTypes = new ServerMessage.ServerMessageType[0];
         }
-        assertMessages(user.username(), userExpectedTypes, messages.get(user.username()));
+        assertMessages(user.username(), userExpectedTypes, messages.get(user.username()), description);
         for(WebsocketUser inGameUser : inGame) {
-            assertMessages(inGameUser.username(), inGameExpectedTypes, messages.get(inGameUser.username()));
+            assertMessages(inGameUser.username(), inGameExpectedTypes, messages.get(inGameUser.username()), description);
         }
         for(WebsocketUser otherUser : otherClients) {
-            assertMessages(otherUser.username(), new ServerMessage.ServerMessageType[0], messages.get(otherUser.username()));
+            assertMessages(otherUser.username(), new ServerMessage.ServerMessageType[0], messages.get(otherUser.username()), description);
         }
     }
 
-    private void assertMessages(String username, ServerMessage.ServerMessageType[] expectedTypes, List<TestMessage> messages) {
-        Assertions.assertEquals(expectedTypes.length, messages.size(), "Expected %d messages for %s, got %d: %s"
-                .formatted(expectedTypes.length, username, messages.size(), messages));
+    private void assertMessages(String username, ServerMessage.ServerMessageType[] expectedTypes, List<TestMessage> messages, String description) {
+        Assertions.assertEquals(expectedTypes.length, messages.size(), "For command '%s' user '%s' expected %d messages, got %d: %s"
+                .formatted(description, username, expectedTypes.length, messages.size(), messages));
         Arrays.sort(expectedTypes);
         messages.sort(Comparator.comparing(TestMessage::getServerMessageType));
         try {
@@ -388,8 +388,8 @@ public class WebSocketTests {
                 }
             }
         } catch(AssertionError e) {
-            Assertions.fail("Expected message types matching %s for %s, got %s"
-                    .formatted(Arrays.toString(expectedTypes), username, messages.reversed()), e);
+            Assertions.fail("\nFor command '%s' user '%s' expected message types matching %s\nGot: %s\nCause: %s"
+                    .formatted(description, username, Arrays.toString(expectedTypes), messages, e.getMessage()), e);
         }
     }
 
@@ -430,5 +430,5 @@ public class WebSocketTests {
         return types;
     }
 
-    private static record WebsocketUser(String username, String authToken) { }
+    private record WebsocketUser(String username, String authToken) { }
 }

--- a/starter-code/6-gameplay/passoff/server/WebSocketTests.java
+++ b/starter-code/6-gameplay/passoff/server/WebSocketTests.java
@@ -375,8 +375,8 @@ public class WebSocketTests {
     }
 
     private void assertMessages(String username, ServerMessage.ServerMessageType[] expectedTypes, List<TestMessage> messages, String description) {
-        Assertions.assertEquals(expectedTypes.length, messages.size(), "For command '%s' user '%s' expected %d messages, got %d: %s"
-                .formatted(description, username, expectedTypes.length, messages.size(), messages));
+        Assertions.assertEquals(expectedTypes.length, messages.size(), "For command '%s' user '%s' expected %d messages with types %s, got %d: %s"
+                .formatted(description, username, expectedTypes.length, Arrays.toString(expectedTypes), messages.size(), messages));
         Arrays.sort(expectedTypes);
         messages.sort(Comparator.comparing(TestMessage::getServerMessageType));
         try {


### PR DESCRIPTION
Currently some students have issues with figuring out why their code may not pass the WebSocket tests. The cause of this the most is some tests send multiple messages and they don't know exactly how far into the test it got or on which command the test failed. In addition, sometimes important test failure information is buried in the "caused by" section of the stack trace. This aims to fix both issues. I wrote this last December but kept forgetting to make the PR with it.

Additional Note:  This does not change anything about what the tests are testing for, just how it reports problems they find, if any. There shouldn't need to be any videos or instruction changed based off this.

## Examples

### Example 1: Not sending notifications to other connected players when a new player joins (or not actually storing that a player connected when they connect)

Current error output (student may assume they didn't send a message to the first player on their first connect when they did and didn't send a notification when the second player connected)
```
org.opentest4j.AssertionFailedError: Expected 1 messages for white, got 0: [] ==> 
Expected :1
Actual   :0
```

Same problem with tests from this PR (makes it clear which command didn't work as expected)
```
org.opentest4j.AssertionFailedError: For command 'black player connect' user 'white' expected 1 messages, got 0: [] ==> 
Expected :1
Actual   :0
```


### Example 2: Sending a message with misnamed or missing variables in the JSON

Current error output (student may assume they misformatted the message to the first player on their first connect when that worked correctly but the notification sent to the first player when the second player connected was the one incorrectly formatted. The student may also not read deeply enough to see specifics and the help message `(Make sure it's specifically called 'message')`) 
```
org.opentest4j.AssertionFailedError: Expected message types matching [NOTIFICATION] for white, got [Msg{serverMessageType=NOTIFICATION, message=null}]
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:42)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:147)
	at passoff.server.WebSocketTests.assertMessages(WebSocketTests.java:391)
	at passoff.server.WebSocketTests.assertCommandMessages(WebSocketTests.java:370)
	at passoff.server.WebSocketTests.connectToGame(WebSocketTests.java:314)
	at passoff.server.WebSocketTests.setupNormalGame(WebSocketTests.java:281)
	at passoff.server.WebSocketTests.connectGood(WebSocketTests.java:73) <29 internal lines>	
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) <9 internal lines>
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) <28 internal lines>
Caused by: org.opentest4j.AssertionFailedError: white's NOTIFICATION message did not contain a message (Make sure it's specifically called 'message') ==> expected: not <null>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertNotNull.failNull(AssertNotNull.java:49)
	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:35)
	at org.junit.jupiter.api.Assertions.assertNotNull(Assertions.java:309)
	at passoff.server.WebSocketTests.assertNotification(WebSocketTests.java:410)
	at passoff.server.WebSocketTests.assertMessages(WebSocketTests.java:386)
	... 72 more
```

Same problem with tests from this PR (makes it clear which command didn't work as expected, duplicates the important info from the middle of the stack trace to the top)
```
org.opentest4j.AssertionFailedError: 
For command 'black player connect' user 'white' expected message types matching [NOTIFICATION]
Got: [Msg{serverMessageType=NOTIFICATION, message=null}]
Cause: white's NOTIFICATION message did not contain a message (Make sure it's specifically called 'message') ==> expected: not <null>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:42)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:147)
	at passoff.server.WebSocketTests.assertMessages(WebSocketTests.java:395)
	at passoff.server.WebSocketTests.assertCommandMessages(WebSocketTests.java:374)
	at passoff.server.WebSocketTests.connectToGame(WebSocketTests.java:318)
	at passoff.server.WebSocketTests.setupNormalGame(WebSocketTests.java:285)
	at passoff.server.WebSocketTests.connectGood(WebSocketTests.java:77) <29 internal lines>	
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) <9 internal lines>
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) <28 internal lines>
Caused by: org.opentest4j.AssertionFailedError: white's NOTIFICATION message did not contain a message (Make sure it's specifically called 'message') ==> expected: not <null>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertNotNull.failNull(AssertNotNull.java:49)
	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:35)
	at org.junit.jupiter.api.Assertions.assertNotNull(Assertions.java:309)
	at passoff.server.WebSocketTests.assertNotification(WebSocketTests.java:414)
	at passoff.server.WebSocketTests.assertMessages(WebSocketTests.java:390)
	... 72 moreerver.ImprovedWebSocketTests.assertMessages(ImprovedWebSocketTests.java:390)
	... 72 more
```