### PR TITLE
DatabaseTests Server Error/500 Test

### DIFF
--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -53,15 +53,13 @@ public class DatabaseManager {
     }
 
     private static void loadPropertiesFromResources() {
-        try {
-            try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
-                if (propStream == null) {
-                    throw new Exception("Unable to load db.properties");
-                }
-                Properties props = new Properties();
-                props.load(propStream);
-                loadProperties(props);
+        try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
+            if (propStream == null) {
+                throw new Exception("Unable to load db.properties");
             }
+            Properties props = new Properties();
+            props.load(propStream);
+            loadProperties(props);
         } catch (Exception ex) {
             throw new RuntimeException("unable to process db.properties", ex);
         }

--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -4,39 +4,24 @@ import java.sql.*;
 import java.util.Properties;
 
 public class DatabaseManager {
-    private static final String DATABASE_NAME;
-    private static final String USER;
-    private static final String PASSWORD;
-    private static final String CONNECTION_URL;
+    private static String databaseName;
+    private static String dbUsername;
+    private static String dbPassword;
+    private static String connectionUrl;
 
     /*
      * Load the database information for the db.properties file.
      */
     static {
-        try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
-            if (propStream == null) {
-                throw new Exception("file could not be found");
-            }
-            Properties props = new Properties();
-            props.load(propStream);
-            DATABASE_NAME = props.getProperty("db.name");
-            USER = props.getProperty("db.user");
-            PASSWORD = props.getProperty("db.password");
-
-            var host = props.getProperty("db.host");
-            var port = Integer.parseInt(props.getProperty("db.port"));
-            CONNECTION_URL = String.format("jdbc:mysql://%s:%d", host, port);
-        } catch (Exception ex) {
-            throw new RuntimeException("unable to process db.properties", ex);
-        }
+        loadPropertiesFromResources();
     }
 
     /**
      * Creates the database if it does not already exist.
      */
     static public void createDatabase() throws DataAccessException {
-        var statement = "CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME;
-        try (var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
+        var statement = "CREATE DATABASE IF NOT EXISTS " + databaseName;
+        try (var conn = DriverManager.getConnection(connectionUrl, dbUsername, dbPassword);
              var preparedStatement = conn.prepareStatement(statement)) {
             preparedStatement.executeUpdate();
         } catch (SQLException ex) {
@@ -59,11 +44,36 @@ public class DatabaseManager {
     static Connection getConnection() throws DataAccessException {
         try {
             //do not wrap the following line with a try-with-resources
-            var conn = DriverManager.getConnection(CONNECTION_URL, USER, PASSWORD);
-            conn.setCatalog(DATABASE_NAME);
+            var conn = DriverManager.getConnection(connectionUrl, dbUsername, dbPassword);
+            conn.setCatalog(databaseName);
             return conn;
         } catch (SQLException ex) {
             throw new DataAccessException("failed to get connection", ex);
         }
+    }
+
+    private static void loadPropertiesFromResources() {
+        try {
+            try (var propStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("db.properties")) {
+                if (propStream == null) {
+                    throw new Exception("Unable to load db.properties");
+                }
+                Properties props = new Properties();
+                props.load(propStream);
+                loadProperties(props);
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException("unable to process db.properties", ex);
+        }
+    }
+
+    private static void loadProperties(Properties props) {
+        databaseName = props.getProperty("db.name");
+        dbUsername = props.getProperty("db.user");
+        dbPassword = props.getProperty("db.password");
+
+        var host = props.getProperty("db.host");
+        var port = Integer.parseInt(props.getProperty("db.port"));
+        connectionUrl = String.format("jdbc:mysql://%s:%d", host, port);
     }
 }


### PR DESCRIPTION
This adds a test simulating an interruption in connecting to MySQL after the server is already running (assuming the server started with MySQL working normally). It calls each of the seven endpoints with requests that shouldn't be immediately `400 Bad Request`'s and asserts that each endpoint sends back 500 and the body contains an error message with the word "error" in it (same as current `StandardAPITests`)
This also removes the `static` keyword from the inner functional interface which is redundant as inner interfaces are already implicitly static 

I've set this to merge into `next-spring2025` for now, as it's testing something that's already in the spec, but I'm not sure if that would require videos changing or not. If it would, I will have to change this to merge into the fall branch instead.