### PR TITLE
Test Factory detects Debug mode

### DIFF
--- a/starter-code/6-gameplay/passoff/server/TestFactory.java
+++ b/starter-code/6-gameplay/passoff/server/TestFactory.java
@@ -4,17 +4,26 @@ import com.google.gson.GsonBuilder;
 
 public class TestFactory {
 
+    /*
+     * Changing the return value will change how long tests will wait for the server to send messages.
+     * The default for runtime is 3000 Milliseconds (3 seconds), and this will be enough for most computers. 
+     * Feel free to change this as you see fit, just know increasing it can make tests take longer to run.
+     * (On the flip side, if you've got a good computer feel free to decrease it)
+     *
+     * WHILE DEBUGGING the websocket tests, the default runtime is 300000 Milliseconds (5 minutes).
+     * If you feel like you would like more time to debug, you may increase the time as you please.
+     * 
+     * If for some reason the tests seem to time out before reaching a point in the test you feel like they
+     * should be, consider changing the last return value, instead of the default debug value.
+     */
     public static Long getMessageTime() {
-        /*
-         * Changing this will change how long tests will wait for the server to send messages.
-         * 3000 Milliseconds (3 seconds) will be enough for most computers. Feel free to change as you see fit,
-         * just know increasing it can make tests take longer to run.
-         * (On the flip side, if you've got a good computer feel free to decrease it)
-         *
-         * WHILE DEBUGGING the websocket tests, it might be useful to increase this time to give the tests
-         * enough time to receive messages you send while debugging. Just make sure to decrease it when you
-         * stop debugging and start running the tests again.
-         */
+        boolean isDebug = java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()
+            .toString().contains("jdwp");
+
+        if (isDebug){
+            return 300000L;
+        }
+
         return 3000L;
     }
 


### PR DESCRIPTION
While working in CS329 we were instructed to add some code that would detect if VS Code was in debug mode and change some code that would make it easier to debug. I thought about this a little, and wondered if it was possible to do this in the Test Factory where we get the length of time for the tests to pass off. It turns out it is.

# The Problem

Previously, the default time-out for the WebSocket tests was 3 seconds, and if a student planned to debug the tests, it fell on their shoulders to change this value. However, some students don't look very hard at this file, and are surprised that when they debug the WebSocket tests, they get a different test error than what they see in run-time. This is decently common issue, and a lot of students come in and are instructed about the TestFactory, and perhaps walked through their bug.

# The Solution

With these revisions, the code now detects if the tests were launched from the debugger. If so, the tests will time out after 5 minutes, rather than 3 seconds. (Normal runtime still times out after 3 seconds). At this point in the semester, most students have developed their debugging skills, and the extension of debug time should help students debug their problems more independently. 

Michael and I tested that this code does in fact return true in debug mode, and false when not in debug mode. We tested it in Intellij, and I tested it in VS Code using the Java Redhat extension, so I would imagine it works for most IDEs. 