### PR TITLE
Remove Login Bad Request Email Line

### DIFF
--- a/starter-code/3-web-api/passoff/server/StandardAPITests.java
+++ b/starter-code/3-web-api/passoff/server/StandardAPITests.java
@@ -79,7 +79,6 @@ public class StandardAPITests {
         TestUser[] incompleteLoginRequests = {
             new TestUser(null, existingUser.getPassword(), existingUser.getEmail()),
             new TestUser(existingUser.getUsername(), null, existingUser.getEmail()),
-            new TestUser(existingUser.getUsername(), existingUser.getPassword(), null),
         };
 
         for (TestUser incompleteLoginRequest : incompleteLoginRequests) {


### PR DESCRIPTION
Logging in shouldn't have a bad request for not having an email, this removes that line.