### PR TITLE
Refactor ChessPosition, ChessMove, and ChessPiece to Java Records

### DIFF
--- a/shared/src/main/java/chess/ChessMove.java
+++ b/shared/src/main/java/chess/ChessMove.java
@@ -6,24 +6,20 @@ package chess;
  * Note: You can add to this class, but you may not alter
  * signature of the existing methods.
  */
-public class ChessMove {
-
-    public ChessMove(ChessPosition startPosition, ChessPosition endPosition,
-                     ChessPiece.PieceType promotionPiece) {
-    }
-
+public record ChessMove(ChessPosition startPosition, ChessPosition endPosition,
+                        ChessPiece.PieceType promotionPiece) {
     /**
      * @return ChessPosition of starting location
      */
     public ChessPosition getStartPosition() {
-        throw new RuntimeException("Not implemented");
+        return startPosition;
     }
 
     /**
      * @return ChessPosition of ending location
      */
     public ChessPosition getEndPosition() {
-        throw new RuntimeException("Not implemented");
+        return endPosition;
     }
 
     /**
@@ -33,6 +29,6 @@ public class ChessMove {
      * @return Type of piece to promote a pawn to, or null if no promotion
      */
     public ChessPiece.PieceType getPromotionPiece() {
-        throw new RuntimeException("Not implemented");
+        return promotionPiece;
     }
 }

--- a/shared/src/main/java/chess/ChessPiece.java
+++ b/shared/src/main/java/chess/ChessPiece.java
@@ -8,10 +8,7 @@ import java.util.Collection;
  * Note: You can add to this class, but you may not alter
  * signature of the existing methods.
  */
-public class ChessPiece {
-
-    public ChessPiece(ChessGame.TeamColor pieceColor, ChessPiece.PieceType type) {
-    }
+public record ChessPiece(ChessGame.TeamColor pieceColor, ChessPiece.PieceType type) {
 
     /**
      * The various different chess piece options
@@ -29,14 +26,14 @@ public class ChessPiece {
      * @return Which team this chess piece belongs to
      */
     public ChessGame.TeamColor getTeamColor() {
-        throw new RuntimeException("Not implemented");
+        return pieceColor;
     }
 
     /**
      * @return which type of chess piece this piece is
      */
     public PieceType getPieceType() {
-        throw new RuntimeException("Not implemented");
+        return type;
     }
 
     /**

--- a/shared/src/main/java/chess/ChessPosition.java
+++ b/shared/src/main/java/chess/ChessPosition.java
@@ -6,17 +6,13 @@ package chess;
  * Note: You can add to this class, but you may not alter
  * signature of the existing methods.
  */
-public class ChessPosition {
-
-    public ChessPosition(int row, int col) {
-    }
-
+public record ChessPosition(int row, int col) {
     /**
      * @return which row this position is in
      * 1 codes for the bottom row
      */
     public int getRow() {
-        throw new RuntimeException("Not implemented");
+        return row;
     }
 
     /**
@@ -24,6 +20,6 @@ public class ChessPosition {
      * 1 codes for the left row
      */
     public int getColumn() {
-        throw new RuntimeException("Not implemented");
+        return col;
     }
 }


### PR DESCRIPTION
## Summary

This PR refactors the following classes into Java records:
- `ChessPosition`
- `ChessMove`
- `ChessPiece` (as discussed in the issue comments)

## Details

- Converted the above classes to records, simplifying their structure.
- Explicit getter methods (`getRow`, `getColumn`, `getStartPosition`, etc.) are retained for compatibility with existing code and tests.
- The `PieceType` enum and `pieceMoves` method remain unchanged in `ChessPiece`.
- No changes were required in the test files or other usages, as the API is preserved.



Closes #32.