### PR TITLE
BCrypt Register Condition

### DIFF
--- a/starter-code/4-database/passoff/server/DatabaseTests.java
+++ b/starter-code/4-database/passoff/server/DatabaseTests.java
@@ -84,7 +84,7 @@ public class DatabaseTests {
     @Order(2)
     public void bcrypt() {
         serverFacade.register(TEST_USER);
-
+        Assertions.assertEquals(200, serverFacade.getStatusCode(), "Unable to register");
         executeForAllTables(this::checkTableForPassword);
     }
 


### PR DESCRIPTION
Fixes softwareconstruction240/softwareconstruction#296. Tested by throwing a DataAccessException at the top of the Register service.