### PR TITLE
Change Email in StandardAPITests

### DIFF
--- a/starter-code/3-web-api/passoff/server/StandardAPITests.java
+++ b/starter-code/3-web-api/passoff/server/StandardAPITests.java
@@ -301,9 +301,9 @@ public class StandardAPITests {
     @DisplayName("List Multiple Games")
     public void listGamesSuccess() {
         //register a few users to create games
-        TestUser userA = new TestUser("a", "A", "a.A");
-        TestUser userB = new TestUser("b", "B", "b.B");
-        TestUser userC = new TestUser("c", "C", "c.C");
+        TestUser userA = new TestUser("a", "A", "a@mail.com");
+        TestUser userB = new TestUser("b", "B", "b@mail.com");
+        TestUser userC = new TestUser("c", "C", "c@mail.com");
 
         TestAuthResult authA = serverFacade.register(userA);
         TestAuthResult authB = serverFacade.register(userB);


### PR DESCRIPTION
Some students may want to go the extra mile in their code to verify the email string is a valid email string (may use regex, assert the string has a '@' character, etc). However, the StandardAPITests will fail if they try to do this validation because the one of the tests register with email strings that aren't really valid email addresses.
This PR changes that one test so anyone who wants to validate email strings are valid email addresses can do so.