### PR TITLE
Add Operation Name to Database Error Handling Test

### DIFF
--- a/starter-code/4-database/passoff/server/DatabaseTests.java
+++ b/starter-code/4-database/passoff/server/DatabaseTests.java
@@ -113,24 +113,26 @@ public class DatabaseTests {
         Object obj = databaseManagerClass.getDeclaredConstructor().newInstance();
         loadPropertiesMethod.invoke(obj, fakeDbProperties);
 
-        List<Supplier<TestResult>> operations = List.of(
-                () -> serverFacade.clear(),
-                () -> serverFacade.register(TEST_USER),
-                () -> serverFacade.login(TEST_USER),
-                () -> serverFacade.logout(UUID.randomUUID().toString()),
-                () -> serverFacade.createGame(new TestCreateRequest("inaccessible"), UUID.randomUUID().toString()),
-                () -> serverFacade.listGames(UUID.randomUUID().toString()),
-                () -> serverFacade.joinPlayer(new TestJoinRequest(ChessGame.TeamColor.WHITE, 1), UUID.randomUUID().toString())
+        Map<String, Supplier<TestResult>> operations = Map.of(
+                "Clear", () -> serverFacade.clear(),
+                "Register", () -> serverFacade.register(TEST_USER),
+                "Login", () -> serverFacade.login(TEST_USER),
+                "Logout", () -> serverFacade.logout(UUID.randomUUID().toString()),
+                "Create Game", () -> serverFacade.createGame(new TestCreateRequest("inaccessible"), UUID.randomUUID().toString()),
+                "List Games", () -> serverFacade.listGames(UUID.randomUUID().toString()),
+                "Join Game", () -> serverFacade.joinPlayer(new TestJoinRequest(ChessGame.TeamColor.WHITE, 1), UUID.randomUUID().toString())
         );
 
         try {
-            for (Supplier<TestResult> operation : operations) {
+            for (Map.Entry<String, Supplier<TestResult>> operationEntry : operations.entrySet()) {
+                String operationName = operationEntry.getKey();
+                Supplier<TestResult> operation = operationEntry.getValue();
                 TestResult result = operation.get();
                 Assertions.assertEquals(500, serverFacade.getStatusCode(),
-                        "Server response code was not 500 Internal Error");
-                Assertions.assertNotNull(result.getMessage(), "Invalid Request didn't return an error message");
+                        "Server response code was not 500 Internal Error for " + operationName);
+                Assertions.assertNotNull(result.getMessage(), "Invalid Request didn't return an error message for " + operationName);
                 Assertions.assertTrue(result.getMessage().toLowerCase(Locale.ROOT).contains("error"),
-                        "Error message didn't contain the word \"Error\"");
+                        "Error message didn't contain the word \"Error\" for " + operationName);
             }
         } finally {
             Method loadFromResources = databaseManagerClass.getDeclaredMethod("loadPropertiesFromResources");


### PR DESCRIPTION
The current implementation of the Database Error Handling test makes it confusing which `operation` is failing if the `operation` does fail.
This PR converts the list to a map that also has the operation name as the key. Then by iterating through the entrySets of the map, we can then output the operation name if the operation ever fails.