### PR TITLE
Enhance error messages in DatabaseManager

### DIFF
--- a/starter-code/4-database/dataaccess/DatabaseManager.java
+++ b/starter-code/4-database/dataaccess/DatabaseManager.java
@@ -25,7 +25,7 @@ public class DatabaseManager {
              var preparedStatement = conn.prepareStatement(statement)) {
             preparedStatement.executeUpdate();
         } catch (SQLException ex) {
-            throw new DataAccessException("failed to create database", ex);
+            throw new DataAccessException("Error: failed to create database", ex);
         }
     }
 
@@ -48,7 +48,7 @@ public class DatabaseManager {
             conn.setCatalog(databaseName);
             return conn;
         } catch (SQLException ex) {
-            throw new DataAccessException("failed to get connection", ex);
+            throw new DataAccessException("Error: failed to get connection", ex);
         }
     }
 


### PR DESCRIPTION
The starter code error messages don't contain the word "error," which the passoff tests explicitly look for. To reduce confusion for students, I added the word "error" to the DataAccessException messages in DatabaseManager.