### PR TITLE
Refactor makeMove method in WebSocketTests

### DIFF
--- a/starter-code/6-gameplay/passoff/server/WebSocketTests.java
+++ b/starter-code/6-gameplay/passoff/server/WebSocketTests.java
@@ -317,10 +317,13 @@ public class WebSocketTests {
     private void makeMove(WebsocketUser sender, int gameID, ChessMove move, boolean expectSuccess, boolean extraNotification,
                           Set<WebsocketUser> inGame, Set<WebsocketUser> otherClients, String description) {
         TestCommand moveCommand = new TestCommand(sender.authToken(), gameID, move);
-        Map<String, Integer> numExpectedMessages = expectedMessages(sender, 1, inGame, (expectSuccess ? 2 : 0), otherClients);
+        int numExtraNotification = extraNotification ? 1 : 0;
+        int senderExpected = 1 + numExtraNotification;
+        int inGameExpected = (expectSuccess ? 2  + numExtraNotification : 0);
+        Map<String, Integer> numExpectedMessages = expectedMessages(sender, senderExpected, inGame, inGameExpected, otherClients);
         Map<String, List<TestMessage>> actualMessages = environment.exchange(sender.username(), moveCommand, numExpectedMessages, waitTime);
 
-        if(extraNotification && actualMessages.get(sender.username()).size() > 1) {
+        if(extraNotification) {
             assertCommandMessages(actualMessages, expectSuccess, sender, types(LOAD_GAME, NOTIFICATION),
                     inGame, types(LOAD_GAME, NOTIFICATION, NOTIFICATION), otherClients, description);
         }


### PR DESCRIPTION
## Overview
This PR refactors and fixes the makeMove method (in regards to the check/checkmate/stalemate notification message, aka `extraNotification` in the method itself) in the WebSocketTests to:

1. More strictly enforce the requirement in the specs regarding the [MAKE_MOVE UserGameCommand](https://github.com/softwareconstruction240/softwareconstruction/blob/main/chess/6-gameplay/gameplay.md#websocket-interactions), particularly if the move results in check, checkmate, or stalemate.
2. Allow the tests to remain open if a student is debugging their code, regardless of whether the move results in the `extraNotification` or not.

This PR should help students primarily when they are debugging their code for MAKE_MOVE.

## The Issue
There are two closely linked issues with the WebSocketTests as it is implemented currently.
The first is that the WebSocketTests close the connection shortly after receiving one WebSocketMessage for the sender (the user who is making the move) and two WebSocketMessages for other users that are also in the game, regardless of whether the move results in check/checkmate/stalemate. This becomes a problem if a student is trying to debug their code and looking at lines after they send the first notification message, but before they send the `extraNotification` message as the connection will get closed during that time (this was the problem that I was trying to figure out for almost a week with Lilly 😭).

The second issue is with how the if statement is set up. The second half of the if statement allows students to not send the `extraNotification` message at all and still pass all the tests, since the second half of the if statement will evaluate to false, even if `extraNotification` is true. So technically, on a correct implementation, both of them should be true or both of them should be false, so I removed the second half to prevent students that are NOT sending the `extraNotification` from passing the tests.

This should also fix the issue that we've had with students coming in to pass off manually with a TA and not realizing they needed to implement their check/checkmate/stalemate notification even after they pass all the WebSocketTests on the autograder.

## Testing
I have manually tested this change with a variety of _not sending enough/sending too much/sending the right amount_ using my own implementation, as well as running both normally and in debug with breakpoints in critical spots.