### PR TITLE
Fix JavaDoc comment in ChessPosition.java

### DIFF
--- a/shared/src/main/java/chess/ChessPosition.java
+++ b/shared/src/main/java/chess/ChessPosition.java
@@ -21,7 +21,7 @@ public class ChessPosition {
 
     /**
      * @return which column this position is in
-     * 1 codes for the left row
+     * 1 codes for the left column
      */
     public int getColumn() {
         throw new RuntimeException("Not implemented");


### PR DESCRIPTION
Changed incorrect explanation for getColumn() to be for column instead of row