### PR TITLE
Include Error Message in Assertion

### DIFF
--- a/starter-code/4-database/passoff/server/DatabaseTests.java
+++ b/starter-code/4-database/passoff/server/DatabaseTests.java
@@ -130,9 +130,10 @@ public class DatabaseTests {
                 TestResult result = operation.get();
                 Assertions.assertEquals(500, serverFacade.getStatusCode(),
                         "Server response code was not 500 Internal Error for " + operationName);
-                Assertions.assertNotNull(result.getMessage(), "Invalid Request didn't return an error message for " + operationName);
-                Assertions.assertTrue(result.getMessage().toLowerCase(Locale.ROOT).contains("error"),
-                        "Error message didn't contain the word \"Error\" for " + operationName);
+                String errorMessage = result.getMessage();
+                Assertions.assertNotNull(errorMessage, "Invalid Request didn't return an error message for " + operationName);
+                Assertions.assertTrue(errorMessage.toLowerCase(Locale.ROOT).contains("error"),
+                        String.format("Error message didn't contain the word \"Error\" for %s. Error message: \"%s\"", operationName, errorMessage));
             }
         } finally {
             Method loadFromResources = databaseManagerClass.getDeclaredMethod("loadPropertiesFromResources");


### PR DESCRIPTION
I was working with a student, and although the `operationName` is somewhat helpful for determining which endpoint has an issue regarding the wording of the `errorMessage`. It can still be somewhat frustrating if there are multiple places where an error message could be thrown, and you have to figure out which one doesn't have the word "error".
This PR makes it a little clearer where they need to look if they give well-worded error messages.